### PR TITLE
Add deep linking for state reports and bills

### DIFF
--- a/src/components/StatePanel.jsx
+++ b/src/components/StatePanel.jsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useState, useEffect } from "react";
 import { stateData } from "../data/states";
 import { useData } from "../context/DataContext";
 import ResearchCard from "./ResearchCard";
@@ -55,7 +55,7 @@ function SectionHeader({ children }) {
   );
 }
 
-const StatePanel = memo(({ stateAbbr, onClose }) => {
+const StatePanel = memo(({ stateAbbr, onClose, initialBillId }) => {
   const state = stateData[stateAbbr];
   const { getBillsForState, getResearchForState, loading } = useData();
   const [activeBill, setActiveBill] = useState(null);
@@ -64,6 +64,15 @@ const StatePanel = memo(({ stateAbbr, onClose }) => {
 
   // Get bills and research from Supabase
   const bills = getBillsForState(stateAbbr);
+
+  // Open bill from URL hash on mount
+  useEffect(() => {
+    if (initialBillId && bills.length > 0 && !activeBill) {
+      const match = bills.find(b => b.id === initialBillId && b.reformConfig);
+      if (match) setActiveBill(match);
+    }
+  }, [initialBillId, bills.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const research = getResearchForState(stateAbbr);
 
   // Separate research by status
@@ -226,6 +235,7 @@ const StatePanel = memo(({ stateAbbr, onClose }) => {
                     if (bill.reformConfig) {
                       track("bill_clicked", { state_abbr: stateAbbr, bill_id: bill.bill, has_reform: true });
                       setActiveBill(bill);
+                      window.location.hash = `${stateAbbr}/${bill.id}`;
                     }
                   }}
                   style={{
@@ -476,7 +486,10 @@ const StatePanel = memo(({ stateAbbr, onClose }) => {
           stateAbbr={stateAbbr}
           billUrl={activeBill.url}
           bill={activeBill}
-          onClose={() => setActiveBill(null)}
+          onClose={() => {
+            setActiveBill(null);
+            window.location.hash = stateAbbr;
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds hash-based URL routing (`/#UT`, `/#UT/ut-sb60`) so state panels and bill analyzers are directly linkable and bookmarkable
- Page refresh preserves selected state and active bill
- Browser back/forward navigation works via `hashchange` listener
- No new dependencies — uses `window.location.hash` and `history.pushState`

## Test plan
- [ ] `/#UT` opens Utah panel; refresh preserves it
- [ ] `/#UT/ut-sb60` opens Utah panel with SB60 reform analyzer
- [ ] Browser back from bill view returns to state panel (`/#UT`)
- [ ] Browser back from state panel returns to landing (`/`)
- [ ] Pasting `/#OK/ok-hb2229` in a new tab opens Oklahoma + HB2229
- [ ] Clicking a state on the map updates the URL hash
- [ ] Closing the panel clears the hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)