### PR TITLE
Polish reform chart visuals and alignment

### DIFF
--- a/modal_app.py
+++ b/modal_app.py
@@ -23,7 +23,7 @@ image = (
     )
     .run_commands(
         # Clone repo and build - date command busts cache on each deploy
-        "date && echo 'v7'",
+        "date && echo 'v8'",
         f"git clone --branch {BRANCH} --single-branch {REPO_URL} /app",
         "cd /app && npm install --legacy-peer-deps",
         # Anon key is public (read-only, row-level security enforced)

--- a/src/components/reform/BillOverview.jsx
+++ b/src/components/reform/BillOverview.jsx
@@ -42,83 +42,85 @@ const StatusBadge = ({ status }) => {
 
 const ChangeRow = ({ label, baseline, reform, compact }) => (
   <div style={{
-    display: "flex",
-    alignItems: "center",
-    gap: compact ? spacing.sm : spacing.lg,
     padding: compact ? `${spacing.sm} ${spacing.md}` : spacing.lg,
     backgroundColor: colors.background.secondary,
     borderRadius: spacing.radius.lg,
   }}>
-    <div style={{ textAlign: compact ? "left" : "center", flex: 1 }}>
-      {!compact && (
-        <p style={{
-          margin: `0 0 ${spacing.xs}`,
-          fontSize: typography.fontSize.xs,
-          fontFamily: typography.fontFamily.body,
-          color: colors.text.tertiary,
-          textTransform: "uppercase",
-          letterSpacing: "0.5px",
-        }}>
-          Current
-        </p>
-      )}
-      {compact && label && (
-        <p style={{
-          margin: `0 0 2px`,
-          fontSize: typography.fontSize.xs,
-          fontFamily: typography.fontFamily.body,
-          color: colors.text.tertiary,
-        }}>
-          {label}
-        </p>
-      )}
+    {compact && label && (
       <p style={{
-        margin: 0,
-        fontSize: compact ? typography.fontSize.sm : typography.fontSize.lg,
-        fontWeight: typography.fontWeight.semibold,
-        fontFamily: typography.fontFamily.primary,
-        color: colors.text.secondary,
+        margin: `0 0 ${spacing.xs}`,
+        fontSize: typography.fontSize.xs,
+        fontFamily: typography.fontFamily.body,
+        color: colors.text.tertiary,
       }}>
-        {baseline}
+        {label}
       </p>
-    </div>
-
+    )}
     <div style={{
       display: "flex",
       alignItems: "center",
-      justifyContent: "center",
-      width: compact ? 28 : 40,
-      height: compact ? 28 : 40,
-      borderRadius: "50%",
-      backgroundColor: colors.primary[50],
-      flexShrink: 0,
+      gap: compact ? spacing.sm : spacing.lg,
     }}>
-      <ArrowIcon />
-    </div>
-
-    <div style={{ textAlign: compact ? "left" : "center", flex: 1 }}>
-      {!compact && (
+      <div style={{ textAlign: compact ? "left" : "center", flex: 1 }}>
+        {!compact && (
+          <p style={{
+            margin: `0 0 ${spacing.xs}`,
+            fontSize: typography.fontSize.xs,
+            fontFamily: typography.fontFamily.body,
+            color: colors.text.tertiary,
+            textTransform: "uppercase",
+            letterSpacing: "0.5px",
+          }}>
+            Current
+          </p>
+        )}
         <p style={{
-          margin: `0 0 ${spacing.xs}`,
-          fontSize: typography.fontSize.xs,
-          fontFamily: typography.fontFamily.body,
-          color: colors.text.tertiary,
-          textTransform: "uppercase",
-          letterSpacing: "0.5px",
+          margin: 0,
+          fontSize: compact ? typography.fontSize.sm : typography.fontSize.lg,
+          fontWeight: typography.fontWeight.semibold,
+          fontFamily: typography.fontFamily.primary,
+          color: colors.text.secondary,
         }}>
-          Proposed
+          {baseline}
         </p>
-      )}
-      {compact && <div style={{ height: label ? "calc(1em + 2px)" : 0 }} />}
-      <p style={{
-        margin: 0,
-        fontSize: compact ? typography.fontSize.sm : typography.fontSize.lg,
-        fontWeight: typography.fontWeight.bold,
-        fontFamily: typography.fontFamily.primary,
-        color: colors.primary[600],
+      </div>
+
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: compact ? 28 : 40,
+        height: compact ? 28 : 40,
+        borderRadius: "50%",
+        backgroundColor: colors.primary[50],
+        flexShrink: 0,
       }}>
-        {reform}
-      </p>
+        <ArrowIcon />
+      </div>
+
+      <div style={{ textAlign: compact ? "left" : "center", flex: 1 }}>
+        {!compact && (
+          <p style={{
+            margin: `0 0 ${spacing.xs}`,
+            fontSize: typography.fontSize.xs,
+            fontFamily: typography.fontFamily.body,
+            color: colors.text.tertiary,
+            textTransform: "uppercase",
+            letterSpacing: "0.5px",
+          }}>
+            Proposed
+          </p>
+        )}
+        <p style={{
+          margin: 0,
+          fontSize: compact ? typography.fontSize.sm : typography.fontSize.lg,
+          fontWeight: typography.fontWeight.bold,
+          fontFamily: typography.fontFamily.primary,
+          color: colors.primary[600],
+        }}>
+          {reform}
+        </p>
+      </div>
     </div>
   </div>
 );

--- a/src/components/reform/WinnersLosersChart.jsx
+++ b/src/components/reform/WinnersLosersChart.jsx
@@ -174,43 +174,67 @@ export default function WinnersLosersChart({ winnersLosers }) {
       {/* Per-decile rows */}
       {hasDeciles && (
         <div>
-          <div style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "3px",
-          }}>
-            {Array.from({ length: 10 }, (_, i) => {
-              const decile = String(10 - i);
-              return (
-                <div key={decile} style={{ display: "flex", alignItems: "center" }}>
-                  <span style={{
-                    width: 24,
-                    textAlign: "right",
-                    marginRight: spacing.sm,
-                    fontSize: typography.fontSize.xs,
-                    fontFamily: typography.fontFamily.body,
-                    color: colors.text.tertiary,
-                    flexShrink: 0,
-                  }}>
-                    {decile}
-                  </span>
-                  <div style={{ flex: 1 }}>
-                    <StackedRow
-                      label={decile}
-                      data={intraDecile.deciles[decile] || allData}
-                      height={24}
-                    />
+          <div style={{ display: "flex" }}>
+            {/* Y-axis label */}
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+              width: 20,
+            }}>
+              <span style={{
+                writingMode: "vertical-rl",
+                transform: "rotate(180deg)",
+                fontSize: typography.fontSize.xs,
+                fontFamily: typography.fontFamily.body,
+                color: colors.text.tertiary,
+                whiteSpace: "nowrap",
+              }}>
+                Income decile
+              </span>
+            </div>
+
+            {/* Decile numbers + bars */}
+            <div style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "3px",
+              flex: 1,
+            }}>
+              {Array.from({ length: 10 }, (_, i) => {
+                const decile = String(10 - i);
+                return (
+                  <div key={decile} style={{ display: "flex", alignItems: "center" }}>
+                    <span style={{
+                      width: 24,
+                      textAlign: "right",
+                      marginRight: spacing.sm,
+                      fontSize: typography.fontSize.xs,
+                      fontFamily: typography.fontFamily.body,
+                      color: colors.text.tertiary,
+                      flexShrink: 0,
+                    }}>
+                      {decile}
+                    </span>
+                    <div style={{ flex: 1 }}>
+                      <StackedRow
+                        label={decile}
+                        data={intraDecile.deciles[decile] || allData}
+                        height={24}
+                      />
+                    </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
 
-          {/* Axis labels */}
+          {/* X-axis labels */}
           <div style={{
             display: "flex",
             justifyContent: "space-between",
-            marginLeft: 32,
+            marginLeft: 52,
             marginTop: spacing.xs,
             fontSize: typography.fontSize.xs,
             fontFamily: typography.fontFamily.body,
@@ -219,17 +243,6 @@ export default function WinnersLosersChart({ winnersLosers }) {
             <span>0%</span>
             <span>Population share</span>
             <span>100%</span>
-          </div>
-
-          <div style={{
-            textAlign: "center",
-            marginTop: "2px",
-            marginBottom: spacing.sm,
-            fontSize: typography.fontSize.xs,
-            fontFamily: typography.fontFamily.body,
-            color: colors.text.tertiary,
-          }}>
-            Income decile
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- **BillOverview**: Fix arrow/value alignment in compact change rows — label now sits above the value→value row so the arrow lines up with both dollar amounts
- **DecileChart**: Negative bars and labels use grey instead of red; hover tooltip appears centered over each bar showing decile name and exact dollar value
- **WinnersLosersChart**: "Income decile" label moved to a rotated y-axis position instead of below the chart
- Bump Modal cache to v8 for fresh deploy

## Test plan
- [ ] Open a bill with reform analyzer (e.g. UT SB60)
- [ ] Verify arrow aligns horizontally with both dollar values in provision cards
- [ ] Verify negative decile bars are grey, not red
- [ ] Hover over decile bars — tooltip appears centered on the bar with rounded dollar value
- [ ] Winners/losers chart shows "Income decile" as rotated y-axis label

🤖 Generated with [Claude Code](https://claude.com/claude-code)