### PR TITLE
Gradient legend for district map, neutral budget color

### DIFF
--- a/src/components/reform/AggregateImpacts.jsx
+++ b/src/components/reform/AggregateImpacts.jsx
@@ -70,8 +70,6 @@ export default function AggregateImpacts({ impacts }) {
   // Use state income tax revenue impact for display
   // Note: For tax cuts, this is negative (state loses revenue, but households gain)
   const stateIncomeTaxImpact = budgetaryImpact?.stateRevenueImpact ?? budgetaryImpact?.netCost;
-  const isRevenueLoss = stateIncomeTaxImpact < 0;
-  const householdsGain = isRevenueLoss; // Tax cut = households benefit
 
   return (
     <div style={{
@@ -158,7 +156,7 @@ export default function AggregateImpacts({ impacts }) {
             fontSize: typography.fontSize["3xl"],
             fontWeight: typography.fontWeight.bold,
             fontFamily: typography.fontFamily.primary,
-            color: householdsGain ? colors.primary[600] : colors.red[600],
+            color: colors.secondary[900],
           }}>
             {formatCurrency(stateIncomeTaxImpact)}
           </span>


### PR DESCRIPTION
## Summary
- Budgetary impact number is now always black (was green for cuts, red for increases)
- District map legends replaced with gradient scale bar: $0 (gray) → max value (green for benefits, red for costs)
- Color interpolation is now smooth (linear lerp) instead of 3-step thresholds

## Test plan
- [ ] Check district map for a benefit reform (e.g. OK HB2229) — green scale
- [ ] Check district map for a cost reform — red scale
- [ ] Verify budgetary impact text is always black

🤖 Generated with [Claude Code](https://claude.com/claude-code)