### PR TITLE
Show computation date next to version info

### DIFF
--- a/src/components/reform/ReformAnalyzer.jsx
+++ b/src/components/reform/ReformAnalyzer.jsx
@@ -417,7 +417,10 @@ export default function ReformAnalyzer({ reformConfig, stateAbbr, billUrl, bill,
               <span style={{ marginLeft: spacing.sm }}>
                 · <a href="https://github.com/PolicyEngine/policyengine-us" target="_blank" rel="noopener noreferrer" style={{ color: colors.primary[600], textDecoration: "none" }}>-us:v{aggregateImpacts.policyengineUsVersion}</a>
                 {aggregateImpacts.datasetVersion && (
-                  <>{" "}<a href="https://github.com/PolicyEngine/policyengine-us-data" target="_blank" rel="noopener noreferrer" style={{ color: colors.primary[600], textDecoration: "none" }}>-us-data:v{aggregateImpacts.datasetVersion}</a></>
+                  <span style={{ marginLeft: spacing.xl }}><a href="https://github.com/PolicyEngine/policyengine-us-data" target="_blank" rel="noopener noreferrer" style={{ color: colors.primary[600], textDecoration: "none" }}>-us-data:v{aggregateImpacts.datasetVersion}</a></span>
+                )}
+                {aggregateImpacts.computedAt && (
+                  <span style={{ marginLeft: spacing.xl }}>Computed on {new Date(aggregateImpacts.computedAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}</span>
                 )}
               </span>
             )}


### PR DESCRIPTION
## Summary
- Displays "Computed on {date}" next to the policyengine-us and policyengine-us-data version links in the reform analyzer footer
- Adds spacing between version links for readability

## Test plan
- [x] Verify date appears in footer when viewing a computed bill
- [x] Verify no date shown when computedAt is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)