### PR TITLE
Move PR creation from compute_impacts.py to encode-bill agent

### DIFF
--- a/scripts/compute_impacts.py
+++ b/scripts/compute_impacts.py
@@ -746,223 +746,13 @@ def write_to_supabase(supabase, reform_id: str, impacts: dict, reform_params: di
 
 
 # =============================================================================
-# PR CREATION
+# STATUS UPDATE
 # =============================================================================
 
 def update_research_status(supabase, reform_id: str, status: str):
     """Update the research table status for a reform."""
     result = supabase.table("research").update({"status": status}).eq("id", reform_id).execute()
     return result
-
-
-def _format_impacts_section(impacts: dict, year_label: str = "") -> list:
-    """Format a single year's impacts as markdown lines."""
-    lines = []
-    prefix = f" ({year_label})" if year_label else ""
-
-    budgetary = impacts.get("budgetaryImpact", {})
-    poverty = impacts.get("povertyImpact", {})
-    child_poverty = impacts.get("childPovertyImpact", {})
-    wl = impacts.get("winnersLosers", {})
-
-    rev = budgetary.get("stateRevenueImpact", 0)
-    gain_total = wl.get('gainMore5Pct', 0) + wl.get('gainLess5Pct', 0)
-    lose_total = wl.get('loseLess5Pct', 0) + wl.get('loseMore5Pct', 0)
-
-    lines.append(f"| Revenue impact{prefix} | **${rev:,.0f}** |")
-    lines.append(f"| Poverty rate{prefix} | {poverty.get('baselineRate', 0):.2%} to {poverty.get('reformRate', 0):.2%} ({poverty.get('percentChange', 0):+.2f}%) |")
-    lines.append(f"| Child poverty rate{prefix} | {child_poverty.get('baselineRate', 0):.2%} to {child_poverty.get('reformRate', 0):.2%} ({child_poverty.get('percentChange', 0):+.2f}%) |")
-    lines.append(f"| Winners{prefix} | {gain_total:.1%} |")
-    lines.append(f"| Losers{prefix} | {lose_total:.1%} |")
-
-    return lines
-
-
-def generate_pr_body(reform: dict, impacts: dict, analysis_year: int, supabase=None) -> str:
-    """Generate a rich PR body for bill review.
-
-    Includes multi-year impacts if available, provisions, benchmarks,
-    and links to bill text.
-    """
-    lines = []
-    reform_id = reform["id"]
-    state = reform["state"].upper()
-
-    lines.append(f"## Bill Review: {reform['label']}")
-    lines.append("")
-    lines.append(f"**Reform ID**: `{reform_id}`")
-    lines.append(f"**State**: {state}")
-    if reform.get("bill_url"):
-        lines.append(f"**Bill text**: {reform['bill_url']}")
-    if reform.get("description"):
-        lines.append(f"**Description**: {reform['description']}")
-    lines.append("")
-    lines.append("Merging this PR will publish the bill to the dashboard.")
-    lines.append("")
-    lines.append("---")
-    lines.append("")
-
-    # Fetch provisions and multi-year data from DB if available
-    provisions = []
-    impacts_by_year = {}
-    if supabase:
-        try:
-            db_result = supabase.table("reform_impacts").select(
-                "provisions, model_notes"
-            ).eq("id", reform_id).execute()
-            if db_result.data:
-                provisions = db_result.data[0].get("provisions") or []
-                model_notes = db_result.data[0].get("model_notes") or {}
-                if isinstance(model_notes, str):
-                    model_notes = json.loads(model_notes)
-                impacts_by_year = model_notes.get("impacts_by_year", {})
-        except Exception:
-            pass
-
-    # Provisions table
-    if provisions:
-        lines.append("### What we model")
-        lines.append("")
-        lines.append("| Provision | Current | Proposed |")
-        lines.append("|-----------|---------|----------|")
-        for p in provisions:
-            lines.append(f"| {p.get('label', '')} | {p.get('baseline', '')} | {p.get('reform', '')} |")
-        lines.append("")
-
-    # Multi-year impacts table
-    if impacts_by_year and len(impacts_by_year) > 1:
-        lines.append("### Multi-year impacts")
-        lines.append("")
-        lines.append("| Year | Revenue Impact | Poverty Change | Winners | Losers |")
-        lines.append("|------|----------------|----------------|---------|--------|")
-        for year_str in sorted(impacts_by_year.keys()):
-            yr_data = impacts_by_year[year_str]
-            rev = yr_data.get("budgetaryImpact", {}).get("stateRevenueImpact", 0)
-            pov_change = yr_data.get("povertyImpact", {}).get("percentChange", 0)
-            wl = yr_data.get("winnersLosers", {})
-            gain = wl.get('gainMore5Pct', 0) + wl.get('gainLess5Pct', 0)
-            lose = wl.get('loseLess5Pct', 0) + wl.get('loseMore5Pct', 0)
-            lines.append(f"| {year_str} | ${rev:,.0f} | {pov_change:+.2f}% | {gain:.1%} | {lose:.1%} |")
-        lines.append("")
-    else:
-        # Single-year key results
-        lines.append("### Key results")
-        lines.append("")
-        lines.append("| Metric | Value |")
-        lines.append("|--------|-------|")
-        lines.extend(_format_impacts_section(impacts))
-        lines.append("")
-
-    # Decile impact for the computed year
-    decile = impacts.get("decileImpact", {})
-    rel = decile.get("relative", {})
-    avg = decile.get("average", {})
-    if rel:
-        lines.append("### Decile impact (relative change in net income)")
-        lines.append("")
-        lines.append("| Decile | Change | Avg Benefit |")
-        lines.append("|--------|--------|-------------|")
-        for d in range(1, 11):
-            val = rel.get(str(d), rel.get(d, 0))
-            avg_val = avg.get(str(d), avg.get(d, 0))
-            lines.append(f"| {d} | {val:+.2%} | ${avg_val:,.0f} |")
-        lines.append("")
-
-    # District impacts
-    districts = impacts.get("districtImpacts", {})
-    if districts:
-        lines.append("### District impacts")
-        lines.append("")
-        lines.append("| District | Avg Benefit | Winners | Losers | Poverty Change |")
-        lines.append("|----------|-------------|---------|--------|----------------|")
-        for did, dinfo in sorted(districts.items()):
-            avg_b = dinfo.get("avgBenefit", 0)
-            win = dinfo.get("winnersShare", 0)
-            lose = dinfo.get("losersShare", 0)
-            pov = dinfo.get("povertyPctChange", 0)
-            lines.append(f"| {did} | ${avg_b:,.0f} | {win:.0%} | {lose:.0%} | {pov:+.2f}% |")
-        lines.append("")
-
-    # Reform parameters (collapsed)
-    lines.append("<details>")
-    lines.append("<summary>Reform parameters JSON</summary>")
-    lines.append("")
-    lines.append("```json")
-    lines.append(json.dumps(reform["reform"], indent=2))
-    lines.append("```")
-    lines.append("")
-    lines.append("</details>")
-    lines.append("")
-
-    # Version info
-    pe_version = get_changelog_version(str(_PE_US_REPO))
-    data_version = get_changelog_version(str(_PE_US_DATA_REPO))
-    lines.append("### Versions")
-    lines.append(f"- PolicyEngine US: `{pe_version}`")
-    lines.append(f"- Dataset: `{data_version}`")
-    lines.append(f"- Computed: {impacts.get('computedAt', 'N/A')[:10]}")
-    lines.append("")
-
-    return "\n".join(lines)
-
-
-def create_review_pr(reform: dict, impacts: dict, analysis_year: int, supabase=None) -> str:
-    """Create a GitHub PR for bill review.
-
-    Creates a branch bill/{reform-id}, pushes an empty commit, and opens a PR
-    with a rich body containing all impact data. No .md files are written —
-    the PR body is the single source of truth, and the GitHub Action extracts
-    the reform-id from the branch name on merge.
-
-    Returns the PR URL on success, or an error message on failure.
-    """
-    reform_id = reform["id"]
-    branch_name = f"bill/{reform_id}"
-    project_root = Path(__file__).resolve().parent.parent
-
-    # Generate the rich PR body
-    pr_body = generate_pr_body(reform, impacts, analysis_year, supabase=supabase)
-
-    # Git operations
-    def run_git(*cmd):
-        result = subprocess.run(
-            ["git"] + list(cmd),
-            cwd=str(project_root),
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"git {' '.join(cmd)} failed: {result.stderr.strip()}")
-        return result.stdout.strip()
-
-    # Create branch with an empty commit and push
-    run_git("checkout", "-b", branch_name)
-    run_git("commit", "--allow-empty", "-m", f"Bill review: {reform['label']}")
-    run_git("push", "-u", "origin", branch_name)
-
-    # Create PR with gh CLI
-    state = reform["state"].upper()
-    pr_title = f"Bill review: {reform['label']} ({state})"
-
-    pr_result = subprocess.run(
-        [
-            "gh", "pr", "create",
-            "--title", pr_title,
-            "--body", pr_body,
-            "--label", "bill-review",
-        ],
-        cwd=str(project_root),
-        capture_output=True,
-        text=True,
-    )
-
-    # Return to main branch
-    run_git("checkout", "main")
-
-    if pr_result.returncode != 0:
-        return f"Error creating PR: {pr_result.stderr.strip()}"
-
-    return pr_result.stdout.strip()
 
 
 # =============================================================================
@@ -1010,11 +800,6 @@ Examples:
         "--multi-year",
         action="store_true",
         help="Store impacts in impacts_by_year structure (for multi-year analysis)"
-    )
-    parser.add_argument(
-        "--create-pr",
-        action="store_true",
-        help="Create a GitHub PR for review after computing impacts"
     )
     args = parser.parse_args()
 
@@ -1120,12 +905,6 @@ Examples:
             # Set status to in_review
             print("  Setting status to in_review...")
             update_research_status(supabase, reform_id, "in_review")
-
-            # Create PR if requested
-            if args.create_pr:
-                print("  Creating review PR...")
-                pr_url = create_review_pr(reform, impacts, sim_year, supabase=supabase)
-                print(f"  PR: {pr_url}")
 
             print(f"\n  [OK] Complete!")
             results[reform_id] = "computed"


### PR DESCRIPTION
## Summary
- Remove `--create-pr` flag, `generate_pr_body()`, `create_review_pr()`, and `_format_impacts_section()` from `compute_impacts.py` (~250 lines)
- Update `/encode-bill` Phase 5 to remove `--create-pr` references
- Add new Phase 6 to `encode-bill.md` where the agent creates the PR with full research context (fiscal comparisons, data caveats, modeling notes)

The script now only computes and writes to DB. The agent creates the PR with richer context from the research phases.

## Test plan
- [ ] Run `compute_impacts.py --reform-id {id}` without `--create-pr` — computes, writes DB, sets `in_review`, exits cleanly
- [ ] Agent creates PR manually following new Phase 6 instructions
- [ ] PR has `bill-review` label and `bill/{reform-id}` branch
- [ ] Merge PR → GitHub Action sets status to `published`

🤖 Generated with [Claude Code](https://claude.com/claude-code)