### PR TITLE
Replace iframe with Vercel reverse proxy support

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta property="og:description" content="Track PolicyEngine's state-level tax and benefit policy research across all 50 states." />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="PolicyEngine State Legislative Tracker" />
-    <meta property="og:image" content="https://policyengine--state-legislative-tracker.modal.run/policyengine-favicon.svg" />
+    <meta property="og:image" content="https://www.policyengine.org/policyengine-favicon.svg" />
     <meta name="twitter:card" content="summary" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/modal_app.py
+++ b/modal_app.py
@@ -14,7 +14,7 @@ REPO_URL = "https://github.com/PolicyEngine/state-legislative-tracker.git"
 BRANCH = "main"
 
 # Bump this when source code changes to rebuild the app layer
-APP_VERSION = "v21"
+APP_VERSION = "v22"
 
 # Evaluated at deploy time — unique command string busts Modal's layer cache
 _now = datetime.datetime.utcnow().isoformat()
@@ -76,9 +76,9 @@ def web():
     _routes_file = f"{dist_path}/_valid_routes.json"
     valid_routes = set(json.load(open(_routes_file))) if os.path.isfile(_routes_file) else set()
 
-    # Serve static assets
-    if os.path.exists(f"{dist_path}/assets"):
-        api.mount("/assets", StaticFiles(directory=f"{dist_path}/assets"), name="assets")
+    # Serve static assets (renamed from assets/ to _tracker/ to avoid collisions with proxy host)
+    if os.path.exists(f"{dist_path}/_tracker"):
+        api.mount("/_tracker", StaticFiles(directory=f"{dist_path}/_tracker"), name="tracker_assets")
 
     @api.get("/{full_path:path}")
     async def serve_spa(full_path: str):

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -24,7 +24,7 @@ if (!SUPABASE_ANON_KEY) {
   process.exit(1);
 }
 
-const BASE_URL = "https://policyengine--state-legislative-tracker.modal.run";
+const BASE_URL = "https://www.policyengine.org/us/state-legislative-tracker";
 const DIST = join(dirname(new URL(import.meta.url).pathname), "..", "dist");
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/src/components/StatePanel.jsx
+++ b/src/components/StatePanel.jsx
@@ -5,6 +5,7 @@ import ResearchCard from "./ResearchCard";
 import ReformAnalyzer from "./reform/ReformAnalyzer";
 import { colors, typography, spacing } from "../designTokens";
 import { track } from "../lib/analytics";
+import { BASE_PATH } from "../lib/basePath";
 
 const CloseIcon = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -235,7 +236,7 @@ const StatePanel = memo(({ stateAbbr, onClose, initialBillId }) => {
                     if (bill.reformConfig) {
                       track("bill_clicked", { state_abbr: stateAbbr, bill_id: bill.bill, has_reform: true });
                       setActiveBill(bill);
-                      history.pushState(null, "", `/${stateAbbr}/${bill.id}`);
+                      history.pushState(null, "", `${BASE_PATH}/${stateAbbr}/${bill.id}`);
                       window.parent.postMessage({ type: "pathchange", path: `/${stateAbbr}/${bill.id}` }, "*");
                       window.parent.postMessage({ type: "hashchange", hash: `${stateAbbr}/${bill.id}` }, "*");
                     }
@@ -490,7 +491,7 @@ const StatePanel = memo(({ stateAbbr, onClose, initialBillId }) => {
           bill={activeBill}
           onClose={() => {
             setActiveBill(null);
-            history.pushState(null, "", `/${stateAbbr}`);
+            history.pushState(null, "", `${BASE_PATH}/${stateAbbr}`);
             window.parent.postMessage({ type: "pathchange", path: `/${stateAbbr}` }, "*");
             window.parent.postMessage({ type: "hashchange", hash: stateAbbr }, "*");
           }}

--- a/src/lib/basePath.js
+++ b/src/lib/basePath.js
@@ -1,0 +1,2 @@
+export const BASE_PATH = window.location.pathname.startsWith('/us/state-legislative-tracker')
+  ? '/us/state-legislative-tracker' : '';

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,4 +5,5 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  build: { assetsDir: '_tracker' },
 })


### PR DESCRIPTION
## Summary

Closes #106

Prepare the tracker for a **crawler-only reverse proxy** on policyengine.org. Search engines and social scrapers will receive the tracker HTML directly (with proper canonical URLs, structured data, and sitemap on policyengine.org). Regular users continue to see the tracker inside the existing iframe with the full policyengine.org nav/footer — no visual change for humans.

### This repo (tracker)

- Rename Vite `assetsDir` from `assets/` to `_tracker/` to avoid path collisions with app-v2's `/assets/`
- Add `BASE_PATH` module that detects proxied (`/us/state-legislative-tracker`) vs standalone routing
- Update all `pushState` calls in App.jsx and StatePanel.jsx to use `BASE_PATH`
- Update prerender canonical URLs, sitemap, robots.txt to point to `policyengine.org`
- Update `og:image` to policyengine.org domain
- Update Modal static mount from `/assets` to `/_tracker`
- Bump `APP_VERSION` to v22

### Companion changes needed in policyengine-app-v2

- **`vercel.json`**: Add rewrite rules for `/_tracker/:path*` → Modal (assets)
- **`app/middleware.ts`**: For crawler user-agents hitting `/us/state-legislative-tracker/*`, let the Vercel rewrite serve Modal HTML directly instead of the app shell. Regular users still get the iframe page.
- **No changes to iframe page or homepage** — users see the same UI as before

### Architecture

```
Crawlers:  policyengine.org/us/state-legislative-tracker/GA
           → middleware detects bot UA → passes through
           → Vercel rewrite → modal.run/GA → pre-rendered HTML with SEO tags

Users:     policyengine.org/us/state-legislative-tracker/GA
           → middleware returns app shell → iframe loads tracker as before

Assets:    policyengine.org/_tracker/index-*.js
           → Vercel rewrite → modal.run/_tracker/index-*.js
```

### Backward compatibility

All existing URLs continue working:
- `modal.run/GA` — standalone, unchanged (`BASE_PATH` = `''`)
- `policyengine.org/.../state-legislative-tracker` — iframe for users, proxy for crawlers
- Old hash URLs (`#GA`) — redirect logic preserved
- All previously shared links remain valid

### Deploy order

1. **This repo first** → merge, deploy to Modal, verify standalone works
2. **app-v2 second** → add Vercel rewrites + middleware crawler split

## Test plan

- [x] `npm run build` → `dist/_tracker/` has JS/CSS, no `dist/assets/`
- [x] Built `index.html` references `/_tracker/index-*.js`
- [ ] Dev server: click state → URL `/GA`, click bill → `/GA/bill-id`, back button works
- [ ] After Modal deploy: standalone `modal.run/GA` still works
- [ ] After app-v2 deploy: `curl -A Googlebot .../state-legislative-tracker/GA` → tracker HTML with canonical policyengine.org URL
- [ ] After app-v2 deploy: browser visit → iframe with policyengine.org nav (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)