### PR TITLE
Bill review: Enhanced Child and Dependent Care Credit Act (NY)

### DIFF
--- a/scripts/compute_impacts.py
+++ b/scripts/compute_impacts.py
@@ -168,6 +168,7 @@ def get_builtin_reform(reform_name: str):
         "ut_hb210_s2": "policyengine_us.reforms.states.ut.ut_hb210_s2",
         "ut_hb210": "policyengine_us.reforms.states.ut.ut_hb210",
         "va_hb979": "policyengine_us.reforms.states.va.hb979.va_hb979_reform",
+        "ny_a06774_enhanced_cdcc": "policyengine_us.reforms.states.ny.a06774.ny_a06774_enhanced_cdcc",
     }
 
     if reform_name not in builtin_reforms:


### PR DESCRIPTION
## Bill Review: Enhanced Child and Dependent Care Credit Act

**Reform ID**: `ny-a06774`  |  **State**: NY
**Bill text**: https://www.nysenate.gov/legislation/bills/2025/A6774
**Description**: Increases the NY child and dependent care credit to 110% of the federal credit for taxpayers with NY AGI up to $50,000.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| NY Enhanced CDCC | `gov.contrib.states.ny.a06774.in_effect` | Not in effect | 110% of federal CDCC for AGI ≤ $50,000 |

**Note**: This reform uses the structural reform mechanism via `_use_reform: ny_a06774_enhanced_cdcc` which overrides the `ny_cdcc` variable calculation.

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| NY Legislative Budget Office | No fiscal note available | — | — |
| NY Tax Expenditure Report | Current CDCC costs ~$120M/year | Annual | [Tax Expenditure Report](https://www.tax.ny.gov/data/stats/ter/fiscal-year26/personal-income-tax.htm) |

#### Back-of-envelope check
> Eligible population: ~68,000 claimants in $25k-$50k AGI range
> Additional credit: 10% of ~$600 average federal CDCC = ~$60/claimant
> Estimate: 68,000 × $60 = **~$4.1M**
> (Rough estimate — actual varies due to CPS sample representation)

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$2.3M** | — | — |
| Back-of-envelope | -$4-6M | -48% to -62% | Review needed |

**Verdict**: PE estimate is lower than back-of-envelope. This is likely due to:
1. CPS microdata may have fewer households with young children + childcare expenses + AGI in $25k-$50k range
2. The enhancement only applies to households currently claiming the federal CDCC
3. Sample representation differences between CPS and actual NY tax filer data

**Bug fix**: The original reform in PolicyEngine-US had a circular dependency (using `cdcc` instead of `cdcc_potential`). This has been fixed in the local PE-US installation but needs to be submitted as a separate PR to policyengine-us.

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.ny.a06774.in_effect` | 2025-01-01 to 2100-12-31 | true | Section 1, amending Tax Law §606 |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$2,306,929** |
| Poverty rate | 26.54% → 26.53% (-0.01%) |
| Child poverty rate | 25.45% → 25.44% (-0.03%) |
| Winners | 0.24% |
| Losers | 0.00% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 0.00% | $0.00 |
| 2 | 0.00% | $0.05 |
| 3 | 0.00% | $1.76 |
| 4 | 0.00% | $0.35 |
| 5 | 0.00% | $0.18 |
| 6 | 0.00% | $0.75 |
| 7 | 0.00% | $0.00 |
| 8 | 0.00% | $0.00 |
| 9 | 0.00% | $0.00 |
| 10 | 0.00% | $0.08 |

### District impacts (top 5 by benefit)
| District | Total Benefit | Winners | Losers | Poverty Change |
|----------|---------------|---------|--------|----------------|
| NY-15 | $238,105 | 0.6% | 0.0% | 0.0% |
| NY-14 | $207,708 | 0.4% | 0.0% | 0.0% |
| NY-7 | $197,123 | 0.4% | 0.0% | 0.0% |
| NY-9 | $151,786 | 0.3% | 0.0% | -0.03% |
| NY-11 | $141,371 | 0.3% | 0.0% | -0.06% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "_use_reform": "ny_a06774_enhanced_cdcc",
  "gov.contrib.states.ny.a06774.in_effect": {
    "2025-01-01.2100-12-31": true
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.568.2`
- Dataset: `policyengine-us-data v1.48.0`
- Computed: 2026-02-18T15:19:41+00:00

### Additional notes
- This PR also includes an update to `compute_impacts.py` to support the NY A06774 structural reform via `_use_reform`
- A companion PR is needed in policyengine-us to fix the circular dependency in the reform (using `cdcc_potential` instead of `cdcc`)