### PR TITLE
Add PostHog reverse proxy to bypass ad blockers

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,7 +7,8 @@ import { DataProvider } from './context/DataContext.jsx'
 
 if (import.meta.env.VITE_POSTHOG_KEY && import.meta.env.PROD) {
   posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
-    api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
     capture_pageview: true,
     capture_pageleave: true,
     autocapture: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,4 +6,13 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   build: { assetsDir: '_tracker' },
+  server: {
+    proxy: {
+      '/ingest': {
+        target: 'https://us.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ingest/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Routes PostHog analytics through `/ingest` on the Modal app's domain instead of directly to `us.i.posthog.com`, bypassing ad blockers
- Adds `httpx` proxy route in `modal_app.py` that forwards to PostHog ingestion and asset hosts
- Updates PostHog client init to use `/ingest` as `api_host`
- Adds Vite dev proxy so the full flow works locally too

## Test plan
- [x] Tested locally: `POST /ingest/decide` → 200 with valid config JSON
- [x] Tested locally: `POST /ingest/e` → 200 `{"status":"Ok"}`
- [x] Tested locally: `POST /ingest/batch` → 200 `{"status":"Ok"}`
- [x] Tested locally: `GET /ingest/static/recorder.js` → 200
- [x] Verified response headers are clean (no double-gzip bug)
- [x] Confirmed no conflict with app-v2 (uses GA4, not PostHog; tracker loads via iframe from Modal)
- [ ] After deploy: verify `/ingest` returns 200s on production Modal app

🤖 Generated with [Claude Code](https://claude.com/claude-code)