### PR TITLE
Bill review: Eliminate State EITC (CT)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -15,7 +15,7 @@ const descriptions = {
   // Connecticut
   "ct-hb5133": "Increases Connecticut's top marginal income tax rate from 6.99% to 7.99% for high earners (single filers over $500,000, joint filers over $1,000,000).",
   "ct-sb78": "Eliminates the qualifying income thresholds for the personal income tax deductions for Social Security benefits. Currently, filers above $75K (single) / $100K (joint) can only deduct 75% of SS benefits; this bill makes 100% deductible for all.",
-  "ct-sb69": "Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families, plus a $250 bonus per qualifying child.",
+  "ct-sb69": "Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families. We assume the $250 child bonus is also eliminated as the EITC statute is removed from the legal code.",
   "ct-tax-rebate-2026": "Governor Lamont's proposed one-time tax rebate providing $200 per person ($400 for joint filers) to Connecticut residents with AGI below $200,000 (single) or $400,000 (joint).",
   "ct-hb5134": "Creates a new refundable child tax credit of $600 per qualifying child (up to 3 children) for Connecticut families with federal AGI below $100,000 (single) or $200,000 (joint). Children must be under age 18. Effective tax year 2026.",
 


### PR DESCRIPTION
## Bill Review: Eliminate State EITC

**Reform ID**: `ct-sb69`  |  **State**: CT
**Bill text**: https://www.cga.ct.gov/2026/TOB/S/PDF/2026SB-00069-R00-SB.PDF
**Description**: Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families, plus a $250 bonus per qualifying child.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| CT EITC Match Rate | `gov.states.ct.tax.income.credits.eitc.match` | 40% of federal EITC | 0% (eliminated) |
| CT EITC Child Bonus | `gov.states.ct.tax.income.credits.eitc.qualifying_child_bonus.in_effect` | $250/child | Eliminated |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| No official fiscal note | — | — | — |

#### Back-of-envelope check
> CT EITC provides 40% of federal EITC
> Federal EITC max ~$7,830 (3+ children) → CT max ~$3,132 + $250 bonus
> ~15% of CT households claim EITC
> Rough estimate: 200,000 households × ~$900 avg = **~$180M**

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **+$184M** | — | — |
| Back-of-envelope | ~$180M | +2% | Excellent |

**Verdict**: PE estimate aligns well with back-of-envelope calculation.

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.states.ct.tax.income.credits.eitc.match` | 2026-01-01 | 0 | Section 1 (repeal of § 12-704e) |
| `gov.states.ct.tax.income.credits.eitc.qualifying_child_bonus.in_effect` | 2026-01-01 | false | Section 1 (cascading from EITC repeal) |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **+$183,701,328** (savings from eliminating EITC) |
| Poverty rate | 20.07% → 20.50% (+2.1%) |
| Child poverty rate | 16.63% → 17.60% (+5.8%) |
| Winners | 0.0% |
| Losers | 15.1% |

### Decile impact
| Decile | Relative Change | Avg Impact |
|--------|-----------------|------------|
| 1 | -0.54% | -$115 |
| 2 | -0.47% | -$223 |
| 3 | -0.43% | -$276 |
| 4 | -0.38% | -$295 |
| 5 | -0.15% | -$143 |
| 6 | -0.06% | -$70 |
| 7 | -0.08% | -$114 |
| 8 | -0.02% | -$26 |
| 9 | -0.02% | -$48 |
| 10 | ~0% | -$1 |

Lower-income deciles (1-4) are most affected, with households losing $115-$295 on average.

### District impacts
| District | Avg Impact | Winners | Losers | Poverty Change | Child Poverty Change |
|----------|------------|---------|--------|----------------|---------------------|
| CT-1 | -$151 | 0% | 15% | +1.6% | +4.7% |
| CT-2 | -$111 | 0% | 13% | +1.3% | +4.0% |
| CT-3 | -$151 | 0% | 15% | +2.8% | +6.2% |
| CT-4 | -$138 | 0% | 16% | +3.3% | +8.5% |
| CT-5 | -$149 | 0% | 16% | +1.6% | +4.1% |

**Note**: CT-4 shows highest child poverty increase (+8.5%), despite being known for affluent areas, indicating pockets of low-income working families.

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.states.ct.tax.income.credits.eitc.match": {
    "2026-01-01": 0
  },
  "gov.states.ct.tax.income.credits.eitc.qualifying_child_bonus.in_effect": {
    "2026-01-01": false
  }
}
```

</details>

### Related Issues

- PolicyEngine-US issue to fix child bonus eligibility check: https://github.com/PolicyEngine/policyengine-us/issues/7468

### Versions
- PolicyEngine US: `1.579.0`
- Dataset: `policyengine-us-data v1.48.0`
- Computed: 2026-02-23