### PR TITLE
Bill review: Establishing a Refundable Child Tax Credit (CT)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -16,6 +16,7 @@ const descriptions = {
   "ct-hb5133": "Increases Connecticut's top marginal income tax rate from 6.99% to 7.99% for high earners (single filers over $500,000, joint filers over $1,000,000).",
   "ct-sb00078": "Eliminates the qualifying income thresholds for the personal income tax deductions for Social Security benefits. Currently, filers above $75K (single) / $100K (joint) can only deduct 75% of SS benefits; this bill makes 100% deductible for all.",
   "ct-sb69": "Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families, plus a $250 bonus per qualifying child.",
+  "ct-hb5134": "Creates a new refundable child tax credit of $600 per qualifying child (up to 3 children) for Connecticut families with federal AGI below $100,000 (single) or $200,000 (joint). Children must be under age 18. Effective tax year 2026.",
 
   // Washington DC
   "dc-hjr142": "Congressional resolution disapproving the D.C. Income and Franchise Tax Conformity and Revision Emergency Amendment Act of 2025, which would eliminate the $1,000 Child Tax Credit and revert the EITC match for households with children from 100% to 85%.",


### PR DESCRIPTION
## Bill Review: Establishing a Refundable Child Tax Credit

**Reform ID**: `ct-hb5134`  |  **State**: CT
**Bill text**: https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05134-R00-HB.PDF
**Description**: Creates a new refundable child tax credit of $600 per qualifying child (up to 3 children) for Connecticut families with federal AGI below $100,000 (single) or $200,000 (joint). Children must be under age 18. Effective tax year 2026.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| CT Refundable CTC | `gov.contrib.states.ct.refundable_ctc.in_effect` | None | $600/child (up to 3) |

**Credit Details:**
- Amount: $600 per qualifying child
- Max children: 3
- Max benefit: $1,800 per family
- Income threshold: <$100K (single/HoH), ≤$200K (joint)
- Child age limit: Under 18

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| DataHaven | $306M | Annual | [Report](https://ctdatahaven.org/report/proposed-connecticut-child-tax-credit-estimating-impacts-towns-legislative-districts-and/) |
| United Way of CT | $300M | Annual | [2026 Policy Agenda](https://www.ctunitedway.org/advocacy/policy-2-3/) |

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PolicyEngine | **$324M** | — | — |
| DataHaven | $306M | +5.9% | ✅ Excellent |
| United Way | $300M | +8.0% | ✅ Excellent |

**Verdict**: PE estimate is within 6-8% of external estimates — excellent alignment.

The slight difference may be due to:
- PE uses CPS microdata vs Census ACS (DataHaven)
- PE's 2026 income projections vs historical ACS data
- Different child counting methodology

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.ct.refundable_ctc.in_effect` | 2026-01-01 | true | Section 1 |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$323,651,755** (cost) |
| Poverty rate | 20.07% → 19.72% (-1.7%) |
| Child poverty rate | 16.63% → 15.87% (-4.6%) |
| Winners | 36.2% |
| Losers | 0.0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | +0.35% | +$74 |
| 2 | +0.37% | +$172 |
| 3 | +0.50% | +$319 |
| 4 | +0.49% | +$388 |
| 5 | +0.39% | +$363 |
| 6 | +0.33% | +$368 |
| 7 | +0.34% | +$457 |
| 8 | +0.18% | +$297 |
| 9 | +0.05% | +$118 |
| 10 | ~0% | +$32 |

Benefits concentrated in deciles 3-7 (working/middle-class families with children).

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change | Child Poverty Change |
|----------|-------------|---------|--------|----------------|---------------------|
| CT-1 | +$264 | 38% | 0% | -1.5% | -3.8% |
| CT-2 | +$244 | 35% | 0% | -0.9% | -3.0% |
| CT-3 | +$257 | 37% | 0% | -1.4% | -3.9% |
| CT-4 | +$225 | 36% | 0% | -2.3% | -5.2% |
| CT-5 | +$245 | 35% | 0% | -2.5% | -6.9% |

**Note**: CT-5 shows the largest child poverty reduction (-6.9%), indicating higher concentration of eligible families with children.

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.contrib.states.ct.refundable_ctc.in_effect": {
    "2026-01-01": true
  }
}
```

</details>

### Changes in this PR

- Added bill description to `src/data/analysisDescriptions.js` (version-controlled)

### Versions
- PolicyEngine US: `1.580.0`
- Dataset: `policyengine-us-data v1.48.0`
- Computed: 2026-02-23