### PR TITLE
Bill review: CTC Marriage Penalty + WFC Reform (MN)

### DIFF
--- a/scripts/generate_household_chart.py
+++ b/scripts/generate_household_chart.py
@@ -90,6 +90,30 @@ def classify_reform(reform_params: dict, provisions: list | None = None) -> dict
 
     combined = param_keys + " " + prov_text
 
+    # Marriage/joint-related reforms (check before CTC/EITC so joint CTC reforms
+    # use a married archetype rather than single parent)
+    if "joint" in param_keys or "married" in param_keys or "filing_status" in param_keys:
+        has_children = any(
+            kw in combined for kw in ["ctc", "child", "cwfc", "dependent"]
+        )
+        if has_children:
+            return {
+                "archetype": "Married couple, 2 children (ages 6, 14)",
+                "adults": [40, 38],
+                "children": [6, 14],
+                "is_married": True,
+                "earnings_max": 250_000,
+                "thresholds": thresholds,
+            }
+        return {
+            "archetype": "Married couple, no children",
+            "adults": [40, 38],
+            "children": [],
+            "is_married": True,
+            "earnings_max": 400_000,
+            "thresholds": thresholds,
+        }
+
     # EITC reforms
     if "eitc" in combined or "earned_income" in combined:
         return {
@@ -109,17 +133,6 @@ def classify_reform(reform_params: dict, provisions: list | None = None) -> dict
             "children": [6, 14],
             "is_married": False,
             "earnings_max": 250_000,
-            "thresholds": thresholds,
-        }
-
-    # Marriage/joint-related reforms
-    if "joint" in combined or "married" in combined or "filing_status" in combined:
-        return {
-            "archetype": "Married couple, no children",
-            "adults": [40, 38],
-            "children": [],
-            "is_married": True,
-            "earnings_max": 400_000,
             "thresholds": thresholds,
         }
 


### PR DESCRIPTION
## Bill review: MN HF2197 CTC Marriage Penalty + WFC Reform

**Reform ID**: `mn-hf2197-ctc-wfc-marriage-penalty`  |  **State**: MN
**Bill text**: https://www.revisor.mn.gov/bills/bill.php?b=House&f=HF2197&ssn=0&y=2025
**Description**: Increases CTC phaseout threshold for joint filers to $75,000 and other filers to $37,500, eliminates WFC for childless adults.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| CTC joint phaseout threshold | `...cwfc.phase_out.threshold.joint` | $35,000 (2023), ~$37,910 (2025 adj.) | $75,000 |
| CTC other filer phaseout threshold | `...cwfc.phase_out.threshold.other` | $29,500 (2023), ~$31,950 (2025 adj.) | $37,500 |
| Eliminate WFC for childless adults | `...cwfc.wfc.eligible.childless_adult_age.minimum` | Age 19+ | 999 (no eligible childless adults) |

Two provisions: (1) raises CTC phaseout thresholds above marriage-neutral levels, and (2) eliminates WFC for childless adults. The WFC elimination is modeled by setting the minimum eligible age to 999, which effectively makes no childless adult eligible.

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| MN Dept of Revenue (HITS 7.5 model) | +$8.5M (FY2026), +$0.2M (FY2027), -$3.3M (FY2028), -$8.4M (FY2029) | Fiscal year | [Revenue Analysis](https://www.revenue.state.mn.us/sites/default/files/2025-03/hf2197-cwfc-eligibility-and-phase-out-1.pdf) |

The DOR revenue analysis (March 24, 2025) used the HITS 7.5 Model. Key findings:
- The revenue impact is a combination of **revenue gain from eliminating childless WFC** and **revenue loss from increased phaseout thresholds**
- In early years, the WFC savings roughly offset the CTC expansion cost (net +$8.5M in FY2026)
- The CTC expansion cost grows faster than WFC savings, leading to net losses by FY2028
- About **106,500 taxpayers** would see an average increased credit of **$962**
- About **318,700 returns** would see an average decreased credit of **$348** (childless adults losing WFC)

#### PE vs external comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$216M** | — | — |
| MN DOR | +$8.5M (FY2026) | — | **Major discrepancy** |

**⚠️ PE estimate diverges significantly from the official DOR revenue analysis.** The same CPS microdata issue identified in HF2502 applies here — PE overestimates the number of joint filers receiving CWFC, inflating the CTC expansion cost component. Meanwhile, PE's WFC childless elimination savings (~$83M) are closer to DOR's implied figure but don't fully offset the inflated CTC cost.

**The DOR estimate based on actual tax return data should be considered more authoritative.** DOR shows this bill is roughly budget-neutral in early years, shifting resources from childless adults to families with children.

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.states.mn.tax.income.credits.cwfc.phase_out.threshold.joint` | 2025-01-01.2100-12-31 | 75,000 | Section 1 |
| `gov.states.mn.tax.income.credits.cwfc.phase_out.threshold.other` | 2025-01-01.2100-12-31 | 37,500 | Section 1 |
| `gov.states.mn.tax.income.credits.cwfc.wfc.eligible.childless_adult_age.minimum` | 2025-01-01.2100-12-31 | 999 | Section 2 |

Note: Setting childless_adult_age.minimum to 999 means no adult passes the age range check in `mn_wfc_eligible`, so `demographic_eligible = has_child` only.

### Key results (PE — see validation caveat above)
| Metric | Value |
|--------|-------|
| Revenue impact (PE) | **-$216M** |
| Revenue impact (DOR) | **+$8.5M** (FY2026), growing to **-$8.4M** (FY2029) |
| Poverty rate | 12.23% → 12.27% (+0.34%) |
| Child poverty rate | 7.99% → 7.79% (-2.49%) |
| Winners | 17.7% |
| Losers | 17.2% |

Note: Overall poverty increases slightly because childless adults lose WFC. Child poverty decreases significantly due to the expanded CTC thresholds.

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|----------------|-------------|
| 1 | -0.50% | -$136 |
| 2 | 0.17% | $89 |
| 3 | 0.39% | $262 |
| 4 | 0.43% | $349 |
| 5 | 0.33% | $313 |
| 6 | 0.14% | $154 |
| 7 | 0.06% | $72 |
| 8 | 0.05% | $73 |
| 9 | 0.01% | $11 |
| 10 | 0.00% | $20 |

Note: Decile 1 shows a net loss because low-income childless adults lose WFC benefits that outweigh the CTC gains.

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change | Child Poverty Change |
|----------|-------------|---------|--------|----------------|---------------------|
| MN-1 | $149 | 21% | 16% | +0.36% | -3.82% |
| MN-2 | $104 | 17% | 18% | +0.19% | -1.63% |
| MN-3 | $73 | 14% | 14% | -0.81% | -3.25% |
| MN-4 | $86 | 16% | 18% | -0.23% | -3.33% |
| MN-5 | $41 | 15% | 22% | -0.32% | -2.81% |
| MN-6 | $117 | 17% | 18% | -0.43% | -2.18% |
| MN-7 | $177 | 23% | 15% | +1.14% | -1.02% |
| MN-8 | $124 | 20% | 16% | +2.56% | -1.50% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.states.mn.tax.income.credits.cwfc.phase_out.threshold.joint": {
    "2025-01-01.2100-12-31": 75000
  },
  "gov.states.mn.tax.income.credits.cwfc.phase_out.threshold.other": {
    "2025-01-01.2100-12-31": 37500
  },
  "gov.states.mn.tax.income.credits.cwfc.wfc.eligible.childless_adult_age.minimum": {
    "2025-01-01.2100-12-31": 999
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.201.1`
- Analysis year: 2025