### PR TITLE
Fix intra-decile income change formula doubling percentage changes

### DIFF
--- a/scripts/compute_impacts.py
+++ b/scripts/compute_impacts.py
@@ -361,11 +361,10 @@ def compute_winners_losers(baseline, reformed, state: str, year: int = 2026) -> 
     people = baseline.calculate("household_count_people", year)
     decile = baseline.calculate("household_income_decile", year).values
 
-    # Relative change formula (matching API exactly)
+    # Relative change formula (matching API fix in policyengine-api#3283)
     absolute_change = (reform_income - baseline_income).values
     capped_baseline_income = np.maximum(baseline_income.values, 1)
-    capped_reform_income = np.maximum(reform_income.values, 1) + absolute_change
-    income_change = (capped_reform_income - capped_baseline_income) / capped_baseline_income
+    income_change = absolute_change / capped_baseline_income
 
     # BOUNDS/LABELS approach matching API intra_decile_impact()
     outcome_groups = {}
@@ -499,11 +498,10 @@ def compute_district_impacts(baseline, reformed, state: str, year: int = 2026) -
         print("    Warning: Congressional district data not available")
         return {}
 
-    # Compute relative change for winners calculation (matching API intra_decile_impact)
+    # Compute relative change for winners calculation (matching API fix in policyengine-api#3283)
     absolute_change = reform_income - baseline_income
     capped_baseline = np.maximum(baseline_income, 1)
-    capped_reform = np.maximum(reform_income, 1) + absolute_change
-    relative_change = (capped_reform - capped_baseline) / capped_baseline
+    relative_change = absolute_change / capped_baseline
 
     district_impacts = {}
 


### PR DESCRIPTION
## Summary
- Fixes the same bug identified in policyengine-api#3283
- The relative income change formula was doubling all percentage changes, overstating the proportion of people in the ">5% gain" and ">5% loss" buckets
- Fixed in both `compute_winners_losers()` (statewide) and `compute_district_impacts()` (district-level)

## Root cause

```python
# Bug (old): doubles the change
capped_reform_income = np.maximum(reform_income, 1) + absolute_change
income_change = (capped_reform_income - capped_baseline) / capped_baseline
# When B>=1, R>=1: max(R,1) + (R-B) = 2R-B → (2R-B-B)/B = 2(R-B)/B

# Fix (new):
income_change = absolute_change / capped_baseline
# = (R-B) / max(B,1)
```

## Impact
All previously computed winners/losers data in Supabase is affected. After merging, re-run with `--force` for each bill to correct stored data.

## Test plan
- [ ] Re-run a bill (e.g., `ct-hb5134`) with `--force` and verify winners/losers proportions shift toward "no change" bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)