### PR TITLE
Bill review: An Act Reducing Certain Personal Income Tax Marginal Rates (CT)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -17,6 +17,7 @@ const descriptions = {
   "ct-sb78": "Eliminates the qualifying income thresholds for the personal income tax deductions for Social Security benefits. Currently, filers above $75K (single) / $100K (joint) can only deduct 75% of SS benefits; this bill makes 100% deductible for all.",
   "ct-sb69": "Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families, plus a $250 bonus per qualifying child.",
   "ct-hb5134": "Creates a new refundable child tax credit of $600 per qualifying child (up to 3 children) for Connecticut families with federal AGI below $100,000 (single) or $200,000 (joint). Children must be under age 18. Effective tax year 2026.",
+  "ct-sb100": "Reduces Connecticut's lowest two marginal income tax rates for taxpayers with AGI below $100,000 (single) or $200,000 (joint). Eliminates tax on the first $10,000/$20,000 of income and cuts the next bracket from 4.5% to 3%.",
 
   // Washington DC
   "dc-hjr142": "Congressional resolution disapproving the D.C. Income and Franchise Tax Conformity and Revision Emergency Amendment Act of 2025, which would eliminate the $1,000 Child Tax Credit and revert the EITC match for households with children from 100% to 85%.",


### PR DESCRIPTION
## Bill Review: An Act Reducing Certain Personal Income Tax Marginal Rates

**Reform ID**: `ct-sb100`  |  **State**: CT
**Bill text**: https://www.cga.ct.gov/2026/TOB/S/PDF/2026SB-00100-R00-SB.PDF
**Description**: Reduces Connecticut's lowest two marginal income tax rates for taxpayers with AGI below $100,000 (single) or $200,000 (joint). Eliminates tax on the first $10,000/$20,000 of income and cuts the next bracket from 4.5% to 3%.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| CT SB100 Reform Enabled | `gov.contrib.states.ct.sb100.in_effect` | False | True |
| First Bracket Rate | `gov.contrib.states.ct.sb100.rates.*.rate[0]` | 2% | 0% |
| Second Bracket Rate | `gov.contrib.states.ct.sb100.rates.*.rate[1]` | 4.5% | 3% |
| AGI Eligibility Threshold | `gov.contrib.states.ct.sb100.income_threshold.*` | N/A | $100k (single) / $200k (joint) |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| CT Office of Fiscal Analysis | Not yet published | — | Bill hearing scheduled Feb 27, 2026 |

No official fiscal note is available for this bill yet. The bill was recently introduced and is pending committee consideration.

#### Back-of-envelope check
> Rate changes affect first two brackets for filers under AGI threshold:
> - 2% elimination on first $10k (single) / $20k (joint)
> - 4.5% -> 3% on next bracket ($10k-$50k single / $20k-$100k joint)
> - Only applies to filers with AGI < $100k (single) / $200k (joint)

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.ct.sb100.in_effect` | 2026-01-01 to 2100-12-31 | true | Section 1, amending C.G.S. 12-700 |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$699,238,453** |
| Poverty rate | 20.07% -> 19.91% (-0.79%) |
| Child poverty rate | 16.64% -> 16.38% (-1.58%) |
| Winners | 56.3% |
| Losers | 0.0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 0.20% | $44 |
| 2 | 0.50% | $236 |
| 3 | 0.69% | $441 |
| 4 | 0.77% | $602 |
| 5 | 0.83% | $778 |
| 6 | 0.87% | $977 |
| 7 | 0.76% | $1,019 |
| 8 | 0.58% | $957 |
| 9 | 0.31% | $694 |
| 10 | 0.02% | $200 |

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| CT-1 | $508 | 56% | 0% | -0.30% |
| CT-2 | $556 | 57% | 0% | -0.57% |
| CT-3 | $549 | 58% | 0% | -0.89% |
| CT-4 | $507 | 55% | 0% | -1.34% |
| CT-5 | $549 | 57% | 0% | -0.83% |

<details><summary>Reform parameters JSON</summary>

\`\`\`json
{
  "gov.contrib.states.ct.sb100.in_effect": {
    "2026-01-01.2100-12-31": true
  }
}
\`\`\`

</details>

### Versions
- PolicyEngine US: `1.584.0`
- Dataset: `policyengine-us-data 1.48.0`
- Computed: 2026-02-24T16:10:17

Generated with [Claude Code](https://claude.com/claude-code)