### PR TITLE
Bill review: An Act Increasing And Expanding The Property Tax Credit (CT)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -17,6 +17,7 @@ const descriptions = {
   "ct-sb78": "Eliminates the qualifying income thresholds for the personal income tax deductions for Social Security benefits. Currently, filers above $75K (single) / $100K (joint) can only deduct 75% of SS benefits; this bill makes 100% deductible for all.",
   "ct-sb69": "Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families. We assume the $250 child bonus is also eliminated as the EITC statute is removed from the legal code.",
   "ct-tax-rebate-2026": "Governor Lamont's proposed one-time tax rebate providing $200 per person ($400 for joint filers) to Connecticut residents with AGI below $200,000 (single) or $400,000 (joint).",
+  "ct-hb5009": "Expands Connecticut's property tax credit by tripling the maximum from $300 to $1,000, establishing a $400 minimum floor, and raising income thresholds to benefit more middle-income homeowners.",
   "ct-hb5134": "Creates a new refundable child tax credit of $600 per qualifying child (up to 3 children) for Connecticut families with federal AGI below $100,000 (single) or $200,000 (joint). Children must be under age 18. Effective tax year 2026.",
   "ct-sb100": "Reduces Connecticut's lowest two marginal income tax rates for taxpayers with AGI below $100,000 (single) or $200,000 (joint). Eliminates tax on the first $10,000/$20,000 of income and cuts the next bracket from 4.5% to 3%.",
 


### PR DESCRIPTION
## Bill Review: An Act Increasing And Expanding The Property Tax Credit

**Reform ID**: `ct-hb5009`  |  **State**: CT
**Bill text**: https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05009-R00-HB.PDF
**Description**: Expands Connecticut's property tax credit by tripling the maximum from $300 to $1,000, establishing a $400 minimum floor, and raising income thresholds to benefit more middle-income homeowners.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Maximum Credit | `gov.contrib.states.ct.hb5009.cap` | $300 | $1,000 |
| Minimum Credit Floor | `gov.contrib.states.ct.hb5009.minimum` | None | $400 |
| Phase-out Start (single) | `gov.contrib.states.ct.hb5009.phaseout.start.SINGLE` | $50,500 | $70,000 |
| Phase-out Start (joint) | `gov.contrib.states.ct.hb5009.phaseout.start.JOINT` | $100,500 | $100,000 |
| Phase-out Limit (single) | `gov.contrib.states.ct.hb5009.phaseout.limit.SINGLE` | $109,500 | $130,000 |
| Phase-out Limit (joint) | `gov.contrib.states.ct.hb5009.phaseout.limit.JOINT` | $130,500 | $200,000 |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| House GOP | ~$501M (broader package) | Annual | [Property Tax Relief](https://www.cthousegop.com/post/property-tax-relief) |

Note: The $501M figure appears to cover the broader GOP tax relief package, not HB5009 alone.

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$128M** | - | - |
| House GOP (package) | -$501M | -74% | See note |

**Verdict**: PE estimate is significantly lower than GOP package estimate. This is expected since:
- The $501M covers multiple provisions beyond property tax credit expansion
- CPS may underreport property tax payments
- PE uses sample-weighted estimates vs administrative projections

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.ct.hb5009.in_effect` | 2026-01-01 | true | Section 1 |
| `gov.contrib.states.ct.hb5009.cap` | 2026-01-01 | $1,000 | Section 1 |
| `gov.contrib.states.ct.hb5009.minimum` | 2026-01-01 | $400 | Section 1 |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$128,288,303** |
| Poverty rate | 20.07% -> 20.05% (-0.1%) |
| Winners | 21.3% |
| Losers | 0.0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | ~0% | ~$0 |
| 2 | ~0% | ~$0 |
| 3 | 0.1% | $60 |
| 4 | 0.2% | $130 |
| 5 | 0.2% | $160 |
| 6 | 0.2% | $200 |
| 7 | 0.2% | $200 |
| 8 | 0.1% | $150 |
| 9 | 0.1% | $100 |
| 10 | ~0% | $50 |

Benefits concentrated in middle deciles (4-7), as expected for a property tax credit with income thresholds.

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| CT-1 | $95 | 21.0% | 0% | ~0% |
| CT-2 | $104 | 21.9% | 0% | ~0% |
| CT-3 | $98 | 21.3% | 0% | ~0% |
| CT-4 | $95 | 21.4% | 0% | ~0% |
| CT-5 | $97 | 20.8% | 0% | ~0% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.contrib.states.ct.hb5009.in_effect": {
    "2026-01-01.2100-12-31": true
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.584.0`
- Dataset: `policyengine-us-data 1.48.0`
- Computed: 2026-02-24

Generated with [Claude Code](https://claude.com/claude-code)