### PR TITLE
Bill review: SC H.4216 - Income Tax Reform (SC)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -84,7 +84,8 @@ const descriptions = {
 
   // South Carolina
   "sc-h3492": "South Carolina H.3492 makes the state EITC partially refundable (50% of the nonrefundable amount), effective for tax year 2026.",
-  "sc-h4216": "South Carolina H.4216 would replace the graduated income tax structure with two brackets: 1.99% up to $30,000 of AGI, and 5.21%. The bill would also eliminate the usage of the federal standard and itemized deductions for SC income tax purposes and replace them with the South Carolina Income Adjusted Deduction (SCIAD). Finally, H4216 would cap the state's EITC at a maximum benefit of $200, regardless of what the 125% federal match amount actually equals. H4216 is effective beginning for tax year 2026.",
+  // H4216 amended Feb 24, 2026 - uses structural reform in policyengine-us
+  "sc-h4216": "South Carolina H.4216 replaces the graduated income tax structure with two brackets: 1.99% up to $30,000, and 5.21% above. The bill eliminates federal standard/itemized deductions for SC purposes, replacing them with the South Carolina Income Adjusted Deduction (SCIAD) with phase-outs. It also caps the state EITC at $200 maximum. Effective tax year 2026.",
 
   // Utah
   "ut-sb60": "Utah Senate Bill 60 would reduce the state flat income tax rate from 4.5% to 4.45%.",


### PR DESCRIPTION
## Bill Review: SC H.4216 - Income Tax Reform (Amended Feb 2026)

**Reform ID**: `sc-h4216`  |  **State**: SC
**Bill text**: https://www.scstatehouse.gov/sess126_2025-2026/prever/4216_20260224.htm
**Description**: Replaces graduated income tax with two brackets (1.99%/5.21%), creates SCIAD deduction with phase-outs, and caps SC EITC at $200. Effective tax year 2026.

Merging this PR will publish the bill to the dashboard.

---

### What we model

| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Tax Rate Structure | `gov.contrib.states.sc.h4216.rates` | Graduated (0% to 6.2%) | 1.99% up to $30k, 5.21% above |
| SCIAD Deduction | `gov.contrib.states.sc.h4216.sciad.*` | Federal standard deduction | $15k single, $22.5k HOH, $30k joint (with phase-out) |
| EITC Cap | `gov.contrib.states.sc.h4216.eitc.max` | 125% of federal (uncapped) | Maximum $200 |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| SC Revenue & Fiscal Affairs | -$308.7M | First year | [Fiscal Note](https://www.scstatehouse.gov/sess126_2025-2026/fiscalimpactstatements/H4216%202026-01-13%20updated.pdf) |

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$397.9M** | — | — |
| SC Fiscal Note | -$308.7M | +29% | PE higher |

**Verdict**: PE estimate (-$398M) is 29% above the fiscal note (-$309M). This is within a reasonable range given data source differences (CPS microdata vs state tax return data). The previous estimate (-$163M) was recomputed with an updated dataset, bringing the result much closer to the official estimate. Remaining gap likely reflects differences in income distributions and SCIAD phase-out calculations.

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$397,937,527** |
| Poverty rate | 26.34% → 26.34% (no change) |
| Child poverty rate | No change |
| Winners | 29.7% |
| Losers | 13.3% |

### District impacts
| District | Avg Benefit | Winners | Losers |
|----------|-------------|---------|--------|
| SC-1 | $341 | 31.2% | 13.3% |
| SC-2 | $223 | 30.5% | 13.8% |
| SC-3 | $214 | 28.1% | 13.4% |
| SC-4 | $229 | 30.7% | 12.9% |
| SC-5 | $58 | 29.4% | 13.4% |
| SC-6 | $221 | 30.0% | 12.2% |
| SC-7 | $217 | 28.5% | 13.7% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "_use_reform": "sc_h4216",
  "gov.contrib.states.sc.h4216.in_effect": {
    "2026-01-01.2100-12-31": true
  }
}
```

This reform uses a structural reform class in policyengine-us that implements:
- New tax brackets (Section 1)
- SCIAD deduction with phase-outs (Section 3)
- EITC $200 cap (Section 7)

</details>

### Versions
- PolicyEngine US: policyengine-us with sc_h4216 structural reform
- Dataset: policyengine-us-data (updated March 2026)
- Computed: 2026-03-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
