### PR TITLE
Bill review: Kansas EITC Increase (KS HB2620)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -34,6 +34,7 @@ const descriptions = {
   "il-hb4680": "Increases the Illinois Earned Income Tax Credit match from 20% to 30% of the federal EITC, effective January 1, 2026.",
 
   // Kansas
+  "ks-hb2620": "Increases the Kansas earned income tax credit from 17% to 18% of the federal EITC.",
   "ks-hb2629": "Kansas HB2629 increases the standard deduction base amounts for all filing statuses effective tax year 2026: single from $3,605 to $3,805, joint from $8,240 to $8,640, head of household from $6,180 to $6,480.",
 
   // Massachusetts


### PR DESCRIPTION
## Bill Review: Kansas EITC Increase (HB2620)

**Reform ID**: `ks-hb2620`  |  **State**: KS
**Bill text**: https://www.kslegislature.gov/li/b2025_26/measures/hb2620/
**Description**: Increases the Kansas earned income tax credit from 17% to 18% of the federal EITC.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Kansas EITC match rate | `gov.states.ks.tax.income.credits.eitc_fraction` | 17% | 18% |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| Kansas Division of the Budget | Available but PDF not extractable | Annual | [Fiscal Note](https://kslegislature.gov/li/b2025_26/measures/documents/fisc_note_hb2620_00_0000.pdf) |

#### Back-of-envelope check
> Rate change: 17% → 18% = 1pp increase
> Kansas federal EITC base ≈ $493.4M → 0.01 × $493.4M = **~$4.9M**
> (Rough estimate assuming full participation)

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$4.04M** | — | — |
| Back-of-envelope | -$4.9M | -17.6% | Acceptable |

**Verdict**: PE estimate is within acceptable range of back-of-envelope calculation. Difference likely due to PE modeling actual EITC claiming patterns rather than assuming 100% take-up.

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.states.ks.tax.income.credits.eitc_fraction` | 2026-01-01 | 0.18 (18%) | Section 1 (amending K.S.A. 79-32,205) |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$4,038,033** |
| Poverty rate | 16.53% → 16.53% (-0.01%) |
| Child poverty rate | 12.64% → 12.64% (-0.02%) |
| Winners | 3.6% |
| Losers | 0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 0.020% | $3.92 |
| 2 | 0.015% | $6.36 |
| 3 | 0.012% | $7.28 |
| 4 | 0.011% | $7.54 |
| 5 | 0.005% | $4.04 |
| 6 | 0.003% | $2.58 |
| 7 | 0.003% | $3.98 |
| 8 | 0.001% | $1.10 |
| 9 | 0.0003% | $0.59 |
| 10 | 0.0002% | $1.31 |

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| KS-1 | $5 | 4% | 0% | 0.00pp |
| KS-2 | $4 | 4% | 0% | -0.01pp |
| KS-3 | $3 | 3% | 0% | 0.00pp |
| KS-4 | $5 | 4% | 0% | -0.04pp |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.states.ks.tax.income.credits.eitc_fraction": {
    "2026-01-01": 0.18
  }
}
```

</details>

### Versions
- PolicyEngine US: `unknown` (local dev)
- Dataset: `policyengine-us-data v1.48.0`
- Computed: 2026-03-03T16:04:29Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)