### PR TITLE
Bill review: Oklahoma Income Tax Elimination (OK SB2156)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -75,6 +75,7 @@ const descriptions = {
 
   // Oklahoma
   "ok-hb2229": "Oklahoma HB2229 would double the state EITC match rate from 5% to 10% of the federal credit, effective for tax year 2026.",
+  "ok-sb2156": "Eliminates Oklahoma's personal income tax by setting all bracket rates (currently 2.5%, 3.5%, and 4.5%) to 0% for all filing statuses, effective November 1, 2026.",
 
   // Oregon
   "or-sb1507": "One provision of Oregon state budget bill SB1507 raises the EITC match rate effective for tax year 2026. The match rate increases to 17% for families with young children (under 3) and 14% for others.",


### PR DESCRIPTION
## Bill Review: Oklahoma Income Tax Elimination (SB2156)

**Reform ID**: `ok-sb2156`  |  **State**: OK
**Bill text**: https://www.oklegislature.gov/BillInfo.aspx?Bill=SB2156&Session=2600
**Description**: Eliminates Oklahoma's personal income tax by setting all bracket rates (currently 2.5%, 3.5%, and 4.5%) to 0% for all filing statuses, effective November 1, 2026.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Eliminate OK Personal Income Tax | `gov.states.ok.tax.income.rates.*.brackets[1-3].rate` | 2.5% / 3.5% / 4.5% | 0% (all) |

All 15 bracket rate parameters across 5 filing statuses (single, joint, separate, head of household, surviving spouse) are set to 0%.

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| Oklahoma Tax Commission | -$7.03B | FY27 | [Fiscal Note](https://www.oklegislature.gov/cf_pdf/2025-26%20SUPPORT%20DOCUMENTS/impact%20statements/fiscal/Senate/SB2156%20INT%20FI.PDF) |
| Oklahoma Tax Commission | -$5.30B | FY28 (steady state) | [Fiscal Note](https://www.oklegislature.gov/cf_pdf/2025-26%20SUPPORT%20DOCUMENTS/impact%20statements/fiscal/Senate/SB2156%20INT%20FI.PDF) |
| Oklahoma Policy Institute | -$5.4B to $5.8B | Annual | [Analysis](https://okpolicy.org/fact-check-eliminate-personal-income-tax-january-2025/) |

Note: FY27 includes ~$1.8B in refunds of withholding already paid before Nov 1, 2026 effective date. FY28 is the steady-state annual impact.

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$4.66B** | — | — |
| OK Tax Commission (FY28) | -$5.30B | -12.1% | Acceptable |
| OK Policy Institute | -$5.4B to $5.8B | -14% to -20% | Acceptable |

**Verdict**: PE estimate is within acceptable range (12%) of official fiscal note's steady-state estimate. Difference likely due to: PE uses CPS microdata with income top-coding vs. OK Tax Commission uses tax return projections with full income distribution; different base year assumptions.

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.states.ok.tax.income.rates.single.brackets[1].rate` | 2026-01-01 | 0 (was 2.5%) | Amends 68 O.S. Section 2355 |
| `gov.states.ok.tax.income.rates.single.brackets[2].rate` | 2026-01-01 | 0 (was 3.5%) | Amends 68 O.S. Section 2355 |
| `gov.states.ok.tax.income.rates.single.brackets[3].rate` | 2026-01-01 | 0 (was 4.5%) | Amends 68 O.S. Section 2355 |
| (+ 12 more for joint, separate, HoH, surviving spouse) | | | |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$4,663,628,797** |
| Poverty rate | 20.34% → 20.10% (-0.24pp) |
| Child poverty rate | 17.60% → 17.39% (-0.21pp) |
| Winners | 66.7% |
| Losers | 0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 0.54% | $99 |
| 2 | 0.80% | $332 |
| 3 | 1.20% | $697 |
| 4 | 1.41% | $1,047 |
| 5 | 1.53% | $1,405 |
| 6 | 1.58% | $1,727 |
| 7 | 1.67% | $2,154 |
| 8 | 1.73% | $2,723 |
| 9 | 1.79% | $3,522 |
| 10 | 1.80% | $7,034 |

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| OK-1 | $4,065 | 69.2% | 0% | -0.28pp |
| OK-2 | $2,213 | 62.0% | 0% | -0.18pp |
| OK-3 | $3,575 | 68.8% | 0% | -0.25pp |
| OK-4 | $2,993 | 67.0% | 0% | -0.22pp |
| OK-5 | $3,482 | 66.8% | 0% | -0.26pp |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.states.ok.tax.income.rates.single.brackets[1].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.single.brackets[2].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.single.brackets[3].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.joint.brackets[1].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.joint.brackets[2].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.joint.brackets[3].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.separate.brackets[1].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.separate.brackets[2].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.separate.brackets[3].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.head_of_household.brackets[1].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.head_of_household.brackets[2].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.head_of_household.brackets[3].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.surviving_spouse.brackets[1].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.surviving_spouse.brackets[2].rate": {"2026-01-01.2100-12-31": 0},
  "gov.states.ok.tax.income.rates.surviving_spouse.brackets[3].rate": {"2026-01-01.2100-12-31": 0}
}
```

</details>

### Versions
- PolicyEngine US: `unknown` (local dev)
- Dataset: `policyengine-us-data v1.48.0`
- Computed: 2026-03-03T20:41:33Z

### Notes
- ITEP analysis notes that eliminating the income tax would cause lowest-income households to actually pay $9 MORE in taxes due to loss of refundable credits
- This is a major fiscal impact representing ~37% of Oklahoma's total state tax revenue
- Bill sponsor Senator Dusty Deevers has introduced several related bills (SB305, SB322, SB308) with similar income tax elimination goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)