### PR TITLE
Bill review: Connecticut Refundable Renter's Tax Credit (CT HB5114)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -13,6 +13,7 @@ const descriptions = {
   "co-hb1062": "Eliminates the $20,000 (age 55-64) and $24,000 (age 65+) caps on Colorado's pension and annuity income subtraction, allowing taxpayers age 55+ to deduct all qualifying retirement income (pensions, annuities, IRA distributions, Social Security) from state taxable income, effective tax year 2027.",
 
   // Connecticut
+  "ct-hb5114": "Connecticut HB5114 creates a refundable renter's tax credit equal to 20% of annual rent paid minus 4% of federal AGI, with a maximum credit of $2,500. Eligible renters must have federal AGI below $75,000 (single/MFS/HoH) or $150,000 (MFJ), rent a primary residence for the full year, and not be claimed as a dependent. Effective for tax years beginning January 1, 2027.",
   "ct-hb5133": "Increases Connecticut's top marginal income tax rate from 6.99% to 7.99% for high earners (single filers over $500,000, joint filers over $1,000,000).",
   "ct-sb78": "Eliminates the qualifying income thresholds for the personal income tax deductions for Social Security benefits. Currently, filers above $75K (single) / $100K (joint) can only deduct 75% of SS benefits; this bill makes 100% deductible for all.",
   "ct-sb69": "Eliminates Connecticut's state Earned Income Tax Credit (EITC), which currently provides 40% of the federal EITC to eligible low-income working families. We assume the $250 child bonus is also eliminated as the EITC statute is removed from the legal code.",


### PR DESCRIPTION
## Bill Review: Connecticut Refundable Renter's Tax Credit

**Reform ID**: `ct-hb5114`  |  **State**: CT
**Bill text**: https://www.cga.ct.gov/2026/TOB/H/PDF/2026HB-05114-R01-HB.PDF
**Description**: Connecticut HB5114 creates a refundable renter's tax credit equal to 20% of annual rent paid minus 4% of federal AGI, with a maximum credit of $2,500. Eligible renters must have federal AGI below $75,000 (single/MFS/HoH) or $150,000 (MFJ), rent a primary residence for the full year, and not be claimed as a dependent. Effective for tax years beginning January 1, 2027.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Renter's credit active | `gov.contrib.states.ct.hb5114.in_effect` | No | Yes |
| Rent percentage | `gov.contrib.states.ct.hb5114.rent_percentage` | 0% | 20% |
| AGI reduction rate | `gov.contrib.states.ct.hb5114.agi_reduction_rate` | 0% | 4% |
| Maximum credit | `gov.contrib.states.ct.hb5114.max_credit` | $0 | $2,500 |
| Income limit (single) | `gov.contrib.states.ct.hb5114.income_threshold.SINGLE` | N/A | $75,000 |
| Income limit (joint) | `gov.contrib.states.ct.hb5114.income_threshold.JOINT` | N/A | $150,000 |

### Validation

#### Back-of-envelope check
> CT households: ~1.4M
> Renter share: ~35% = ~490,000 renter households
> Max credit: $2,500
> Maximum potential cost: 490,000 × $2,500 = $1.225B
> With income limits ($75k/$150k) and AGI reduction formula (4% clawback), actual cost is significantly lower
> PE estimate of $562M = ~46% of max, which is reasonable

#### Fiscal note
No official fiscal note available yet (bill in committee).

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$561.7M** |
| Poverty rate | 27.43% → 26.82% (-2.2%) |
| Child poverty rate | 21.12% → 20.16% (-4.5%) |
| Winners | 26.0% |
| Losers | 0.0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 5.92% | $678 |
| 2 | 2.39% | $693 |
| 3 | 1.51% | $656 |
| 4 | 1.06% | $594 |
| 5 | 0.74% | $517 |
| 6 | 0.58% | $492 |
| 7 | 0.15% | $152 |
| 8 | 0.16% | $205 |
| 9 | 0.00% | $5 |
| 10 | 0.00% | $6 |

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| CT-1 | $485 | 26.9% | 0% | N/A |
| CT-2 | $428 | 25.1% | 0% | N/A |
| CT-3 | $493 | 26.9% | 0% | N/A |
| CT-4 | $410 | 25.3% | 0% | N/A |
| CT-5 | $457 | 25.8% | 0% | N/A |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.contrib.states.ct.hb5114.in_effect": {
    "2027-01-01.2100-12-31": true
  }
}
```

</details>

### Model notes
- This analysis uses PolicyEngine Enhanced CPS microdata for Connecticut
- The credit formula is: min(20% × rent - 4% × AGI, $2,500)
- The CPS may not perfectly capture rental patterns for all households
- The credit is fully refundable per Section 1(c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)