### PR TITLE
Bill review: Rhode Island Income Tax Rate Reduction (RI SB2672)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -85,6 +85,7 @@ const descriptions = {
 
   // Rhode Island
   "ri-s2364": "Rhode Island S2364 increases the state earned-income tax credit from 16% to 30% of the federal earned-income credit, effective for tax years beginning on or after January 1, 2027.",
+  "ri-sb2672": "Rhode Island SB2672 reduces personal income tax rates by 10% phased in over five years (2027-2031). All three brackets are reduced by 2% annually: first bracket from 3.75% to 3.38%, second bracket from 4.75% to 4.28%, third bracket from 5.99% to 5.39%. This analysis assumes no pause to the income tax reductions under the fiscal oversight provisions.",
 
   // South Carolina
   "sc-h3492": "South Carolina H.3492 makes the state EITC partially refundable (50% of the nonrefundable amount), effective for tax year 2026.",


### PR DESCRIPTION
## Bill Review: Rhode Island Income Tax Rate Reduction

**Reform ID**: `ri-sb2672`  |  **State**: RI
**Bill text**: https://webserver.rilegislature.gov/BillText/BillText26/SenateText26/S2672.pdf
**Description**: Rhode Island SB2672 reduces personal income tax rates by 10% phased in over five years (2027-2031). All three brackets are reduced by 2% annually: first bracket from 3.75% to 3.38%, second bracket from 4.75% to 4.28%, third bracket from 5.99% to 5.39%. This analysis assumes no pause to the income tax reductions under the fiscal oversight provisions.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed (2031) |
|-----------|-----------|---------|-----------------|
| First bracket rate | `gov.states.ri.tax.income.rate.brackets[0].rate` | 3.75% | 3.38% |
| Second bracket rate | `gov.states.ri.tax.income.rate.brackets[1].rate` | 4.75% | 4.28% |
| Third bracket rate | `gov.states.ri.tax.income.rate.brackets[2].rate` | 5.99% | 5.39% |

### Phase-in Schedule
| Year | First bracket | Second bracket | Third bracket |
|------|---------------|----------------|---------------|
| 2027 | 3.68% | 4.66% | 5.87% |
| 2028 | 3.60% | 4.56% | 5.75% |
| 2029 | 3.53% | 4.47% | 5.63% |
| 2030 | 3.45% | 4.37% | 5.51% |
| 2031 | 3.38% | 4.28% | 5.39% |

### Validation

#### Fiscal note
No official fiscal note available yet (bill in Senate Finance Committee).

#### Back-of-envelope check
> Rate reduction: 10% aggregate cut over 5 years (2% annually of 2026 rates)
> First bracket: 3.75% × 0.90 = 3.375% ≈ 3.38%
> Second bracket: 4.75% × 0.90 = 4.275% ≈ 4.28%
> Third bracket: 5.99% × 0.90 = 5.391% ≈ 5.39%
> Rates match the bill's schedule exactly.

### Key results (Multi-year)
| Year | Revenue Impact | Poverty Change | Winners | No Change |
|------|----------------|----------------|---------|-----------|
| 2027 | **-$34.5M** | -0.001% | 4.6% | 95.4% |
| 2028 | **-$73.6M** | -0.02% | 31.9% | 68.1% |
| 2029 | **-$115.0M** | -0.01% | 49.9% | 50.1% |
| 2030 | **-$162.3M** | -0.01% | 57.4% | 42.6% |
| 2031 | **-$211.9M** | -0.30% | 61.0% | 39.0% |

### Decile impact (2031 - full phase-in)
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 0.33% | $41 |
| 2 | 0.03% | $10 |
| 3 | 0.06% | $29 |
| 4 | 0.11% | $63 |
| 5 | 0.14% | $98 |
| 6 | 0.21% | $184 |
| 7 | 0.25% | $277 |
| 8 | 0.30% | $403 |
| 9 | 0.33% | $595 |
| 10 | 0.62% | $6,050 |

### District impacts (2031)
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| RI-1 | $518 | 61% | 0% | -0.57% |
| RI-2 | $535 | 61% | 0% | -0.03% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.states.ri.tax.income.rate.brackets[0].rate": {
    "2027-01-01.2027-12-31": 0.0368,
    "2028-01-01.2028-12-31": 0.0360,
    "2029-01-01.2029-12-31": 0.0353,
    "2030-01-01.2030-12-31": 0.0345,
    "2031-01-01.2100-12-31": 0.0338
  },
  "gov.states.ri.tax.income.rate.brackets[1].rate": {
    "2027-01-01.2027-12-31": 0.0466,
    "2028-01-01.2028-12-31": 0.0456,
    "2029-01-01.2029-12-31": 0.0447,
    "2030-01-01.2030-12-31": 0.0437,
    "2031-01-01.2100-12-31": 0.0428
  },
  "gov.states.ri.tax.income.rate.brackets[2].rate": {
    "2027-01-01.2027-12-31": 0.0587,
    "2028-01-01.2028-12-31": 0.0575,
    "2029-01-01.2029-12-31": 0.0563,
    "2030-01-01.2030-12-31": 0.0551,
    "2031-01-01.2100-12-31": 0.0539
  }
}
```

</details>

### Model notes
This analysis uses PolicyEngine Enhanced CPS microdata for Rhode Island. Analysis assumes no pause to the income tax reductions under the fiscal oversight provisions in Section (f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)