### PR TITLE
HB2306 HD1

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -29,6 +29,9 @@ const descriptions = {
   "ga-sb476": "Reduces Georgia income tax rate to 4.99% and increases standard deductions to $50,000 for single filers and $100,000 for joint filers, effective January 1, 2026.",
   "ga-hb880": "Hypothetical multi-year analysis of Georgia HB880 assuming all revenue growth triggers are met. Phases in annual income tax rate reductions from 4.99% (2027) to 4.19% (2035), increases standard deductions ($12,000/$24,000 single/joint in 2026 to $17,400/$34,800 in 2035), and raises the dependent exemption ($4,000 in 2026 to $5,800 in 2035). The bill also increases the retirement income exclusion cap from $65,000 to $70,000 for older retirees beginning in 2027.",
 
+  // Hawaii
+  "hi-hb2306": "Freezes Hawaii income tax bracket thresholds at 2025 levels, increases top three marginal rates by 1pp (9%→10%, 10%→11%, 11%→12%), expands the child and dependent care credit (50%-5% match up to $160k AGI vs current 25%-15% up to $50k), and extends Act 163 enhanced credits (40% EITC, expanded CDCC limits, food/excise credit) through 2033. Effective for taxable years beginning after December 31, 2026.",
+
   // Iowa
   "ia-hf1020": "Modifies the Iowa child and dependent care credit by removing the $90,000 income cap and simplifying from 7 brackets to 4. Taxpayers with Iowa net income of $25,000 or more receive 50% of the federal credit (up from 30-40% for middle-income and 0% for high-income). Retroactive to January 1, 2025.",
 


### PR DESCRIPTION
## Summary
- Freezes Hawaii income tax bracket thresholds at 2025 levels (repealing scheduled 2027/2029 increases)
- Increases top 3 marginal rates by 1pp (9%→10%, 10%→11%, 11%→12%)
- Expands CDCC to 50%-5% match rate up to $160k AGI (through 2032)
- Extends Act 163 enhanced credits (40% EITC, CDCC expense limits, food/excise credit) through Dec 31, 2032

## Multi-Year Impacts (2027-2033)

| Year | Revenue | Winners | Losers | Notes |
|------|---------|---------|--------|-------|
| 2027 | +$233.2M | 2.7% | 56.6% | Pause 1 + Tax increases + CDCC expansion |
| 2028 | +$115.7M | 47.5% | 45.6% | Act 163 extension kicks in |
| 2029 | +$296.0M | 43.5% | 53.2% | Pause 2 |
| 2030 | +$310.9M | 43.1% | 53.1% | |
| 2031 | +$320.6M | 43.1% | 52.8% | |
| 2032 | +$342.6M | 42.5% | 54.7% | Last year of credit extensions |
| 2033 | +$488.8M | 1.1% | 60.4% | All credits sunset, only tax changes remain |

**7-year total**: ~$2.1B

## Test plan
- [x] Reform params written to Supabase (150 parameters)
- [x] Impacts computed for 2027-2033
- [x] 2033 sunset properly modeled (EITC, CDCC, food/excise revert to pre-Act 163 levels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)