### PR TITLE
Match household calculator years to computed impact years

### DIFF
--- a/src/components/reform/HouseholdForm.jsx
+++ b/src/components/reform/HouseholdForm.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { colors, typography, spacing } from "../../designTokens";
 
 function formatWithCommas(n) {
@@ -158,6 +159,15 @@ export default function HouseholdForm({
 }) {
   // Use provided years or fall back to defaults
   const taxYears = availableYears?.length > 0 ? availableYears : DEFAULT_TAX_YEARS;
+  const firstYear = taxYears[0];
+
+  // Sync selected year when it's not in the available options
+  useEffect(() => {
+    if (!taxYears.includes(values.year)) {
+      onChange({ ...values, year: firstYear });
+    }
+  }, [firstYear, values.year]);
+
   const handleChange = (field) => (e) => {
     const value = field === "income" || field === "headAge" || field === "spouseAge"
       ? parseInt(e.target.value, 10) || 0

--- a/src/components/reform/ReformAnalyzer.jsx
+++ b/src/components/reform/ReformAnalyzer.jsx
@@ -91,10 +91,10 @@ export default function ReformAnalyzer({ reformConfig, stateAbbr, billUrl, bill,
   // Get pre-computed aggregate impacts (used for version gating + rendering)
   const aggregateImpacts = getImpact(reformConfig.id);
 
-  // Disable household calc only for structural reforms (contrib paths,
-  // _use_reform) when the API version is too old. Parametric reforms
-  // (just changing existing parameter values) work on any API version.
-  // Fail closed: if we can't determine the API version, disable for structural.
+  // Structural reforms (contrib paths, _use_reform) need a minimum API version.
+  // Fail closed: disable while loading AND when version is too old.
+  // This avoids the old disabled→enabled flash by keeping the tab consistently
+  // disabled until the version check confirms support.
   const requiredVersion = aggregateImpacts?.policyengineUsVersion;
   const isStructural = reformNeedsStructuralCode(reformConfig.reform);
   const householdUnsupported =
@@ -253,7 +253,7 @@ export default function ReformAnalyzer({ reformConfig, stateAbbr, billUrl, bill,
               <button
                 key={tab.id}
                 disabled={isDisabled}
-                title={isDisabled ? `Requires PolicyEngine US v${requiredVersion} (API is v${apiVersion})` : undefined}
+                title={isDisabled ? `Requires PolicyEngine US v${requiredVersion} (API is v${apiVersion || "loading..."})` : undefined}
                 onClick={() => {
                   if (isDisabled) return;
                   setActiveTab(tab.id);

--- a/src/components/reform/availableYears.test.js
+++ b/src/components/reform/availableYears.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Tests for the availableYears derivation logic from PR #148.
+ *
+ * In ReformAnalyzer, availableYears is computed as:
+ *   aggregateImpacts?.impactsByYear
+ *     ? Object.keys(aggregateImpacts.impactsByYear).sort()
+ *     : aggregateImpacts?.analysisYear
+ *       ? [aggregateImpacts.analysisYear.toString()]
+ *       : null
+ *
+ * In HouseholdForm, the fallback is:
+ *   availableYears?.length > 0 ? availableYears : DEFAULT_TAX_YEARS
+ */
+
+const DEFAULT_TAX_YEARS = ["2026", "2027", "2028", "2029"];
+
+function deriveAvailableYears(aggregateImpacts) {
+  return aggregateImpacts?.impactsByYear
+    ? Object.keys(aggregateImpacts.impactsByYear).sort()
+    : aggregateImpacts?.analysisYear
+      ? [aggregateImpacts.analysisYear.toString()]
+      : null;
+}
+
+function resolveTaxYears(availableYears) {
+  return availableYears?.length > 0 ? availableYears : DEFAULT_TAX_YEARS;
+}
+
+describe("availableYears derivation (ReformAnalyzer)", () => {
+  it("returns sorted year keys for multi-year analyses", () => {
+    const impacts = {
+      impactsByYear: { "2028": {}, "2026": {}, "2027": {} },
+    };
+    expect(deriveAvailableYears(impacts)).toEqual(["2026", "2027", "2028"]);
+  });
+
+  it("returns single-element array for single-year analyses", () => {
+    const impacts = { analysisYear: 2026 };
+    expect(deriveAvailableYears(impacts)).toEqual(["2026"]);
+  });
+
+  it("converts numeric analysisYear to string", () => {
+    const impacts = { analysisYear: 2029 };
+    const result = deriveAvailableYears(impacts);
+    expect(result).toEqual(["2029"]);
+    expect(typeof result[0]).toBe("string");
+  });
+
+  it("returns null when no impact data exists", () => {
+    expect(deriveAvailableYears(null)).toBeNull();
+    expect(deriveAvailableYears(undefined)).toBeNull();
+    expect(deriveAvailableYears({})).toBeNull();
+  });
+
+  it("prefers impactsByYear over analysisYear when both exist", () => {
+    const impacts = {
+      impactsByYear: { "2027": {}, "2028": {} },
+      analysisYear: 2026,
+    };
+    expect(deriveAvailableYears(impacts)).toEqual(["2027", "2028"]);
+  });
+});
+
+describe("resolveTaxYears (HouseholdForm fallback)", () => {
+  it("uses provided years when available", () => {
+    expect(resolveTaxYears(["2026", "2027"])).toEqual(["2026", "2027"]);
+  });
+
+  it("falls back to defaults when availableYears is null", () => {
+    expect(resolveTaxYears(null)).toEqual(DEFAULT_TAX_YEARS);
+  });
+
+  it("falls back to defaults when availableYears is undefined", () => {
+    expect(resolveTaxYears(undefined)).toEqual(DEFAULT_TAX_YEARS);
+  });
+
+  it("falls back to defaults when availableYears is empty array", () => {
+    expect(resolveTaxYears([])).toEqual(DEFAULT_TAX_YEARS);
+  });
+
+  it("uses single-year array without falling back", () => {
+    expect(resolveTaxYears(["2026"])).toEqual(["2026"]);
+  });
+});
+
+describe("year sync (stale year fix)", () => {
+  // Simulates the useEffect logic in HouseholdForm:
+  // if selected year is not in taxYears, reset to first available
+  function syncYear(currentYear, taxYears) {
+    if (taxYears.length > 0 && !taxYears.includes(currentYear)) {
+      return taxYears[0];
+    }
+    return currentYear;
+  }
+
+  it("resets year when current selection is not in available years", () => {
+    expect(syncYear("2026", ["2027", "2028"])).toBe("2027");
+  });
+
+  it("keeps year when current selection is valid", () => {
+    expect(syncYear("2027", ["2027", "2028"])).toBe("2027");
+  });
+
+  it("resets to first year for single-year analyses", () => {
+    expect(syncYear("2026", ["2029"])).toBe("2029");
+  });
+
+  it("keeps year when using default years and 2026 is selected", () => {
+    expect(syncYear("2026", DEFAULT_TAX_YEARS)).toBe("2026");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `availableYears` prop to HouseholdForm component
- Passes years from `impactsByYear` (multi-year analyses) or `analysisYear` (single-year analyses)
- Falls back to default years (2026-2029) only when no impact data exists

This ensures the household calculator tax year dropdown matches the years for which we've computed impacts for each analysis.

## Test plan
- [ ] Verify multi-year analyses (e.g., Hawaii HB2306) show all computed years in dropdown
- [ ] Verify single-year analyses show only that year in dropdown
- [ ] Verify analyses without impact data fall back to default years

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)