### PR TITLE
Bill review: High-Earner Income Tax Surcharge (RI)

### DIFF
--- a/scripts/compute_impacts.py
+++ b/scripts/compute_impacts.py
@@ -170,6 +170,7 @@ def get_builtin_reform(reform_name: str):
         "va_hb979": "policyengine_us.reforms.states.va.hb979.va_hb979_reform",
         "ny_s04487_newborn_credit": "policyengine_us.reforms.states.ny.s04487.ny_s04487_newborn_credit",
         "sc_h4216": "policyengine_us.reforms.states.sc.h4216.sc_h4216",
+        "ri_high_earner_tax": "policyengine_us.reforms.states.ri.high_earner_tax.ri_high_earner_tax_reform",
     }
 
     if reform_name not in builtin_reforms:

--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -89,6 +89,7 @@ const descriptions = {
   "or-sb1507": "One provision of Oregon state budget bill SB1507 raises the EITC match rate effective for tax year 2026. The match rate increases to 17% for families with young children (under 3) and 14% for others.",
 
   // Rhode Island
+  "ri-h7313": "Creates a 3% additional tax on Rhode Island taxable income exceeding $640,000 (in 2026 dollars), effective for tax years 2027 and thereafter, raising the effective top marginal rate from 5.99% to 8.99%.",
   "ri-s2364": "Rhode Island S2364 increases the state earned-income tax credit from 16% to 30% of the federal earned-income credit, effective for tax years beginning on or after January 1, 2027.",
   "ri-sb2672": "Rhode Island SB2672 reduces personal income tax rates by 10% phased in over five years (2027-2031). All three brackets are reduced by 2% annually: first bracket from 3.75% to 3.38%, second bracket from 4.75% to 4.28%, third bracket from 5.99% to 5.39%. This analysis assumes no pause to the income tax reductions under the fiscal oversight provisions.",
 


### PR DESCRIPTION
## Bill Review: High-Earner Income Tax Surcharge

**Reform ID**: `ri-h7313`  |  **State**: RI
**Bill text**: https://webserver.rilegislature.gov/BillText26/HouseText26/H7313.pdf
**Description**: Creates a 3% additional tax on Rhode Island taxable income exceeding $640,000 (in 2026 dollars), effective for tax years 2027 and thereafter, raising the effective top marginal rate from 5.99% to 8.99%.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| High-Earner Surtax | `gov.contrib.states.ri.high_earner_tax.in_effect` | Not in effect | In effect (3% on income above $640,000) |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| ITEP | $190M/year | Annual | [Testimony](https://itep.org/itep-testimony-miles-trinidad-on-rhode-islands-high-earner-income-tax-surcharge/) |
| EPI | $190M/year (5,700 filers) | Annual | [Testimony](https://economicprogressri.org/publications/testimony-in-support-of-a-personal-income-surtax-on-millionaires-s-2355-senate-committee-on-finance) |
| Tax Foundation | Migration risk warning | - | [Testimony](https://taxfoundation.org/testimony/rhode-island-high-earner-income-tax-surcharge/) |

#### Back-of-envelope check
> Top 1% (~6,100 filers), avg income ~$1.5M above threshold
> 3% × $1.5M × 6,100 = ~$275M (upper bound, assumes all income above threshold)
> (Rough estimate — actual varies due to income distribution)

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **$426.5M** | — | — |
| ITEP/EPI | $190M | +124% | ⚠️ Review needed |
| Back-of-envelope | $275M | +55% | ⚠️ Review needed |

**Verdict**: PE estimate is significantly higher than external estimates (124% higher than ITEP/EPI).

**Likely explanations for discrepancy**:
1. CPS data may overrepresent ultra-high earners in Rhode Island small-state sample
2. PE uses 2027 projections with inflation-adjusted incomes; external estimates may use current-year data
3. Different definitions of taxable income vs AGI
4. External estimates may use more conservative assumptions about affected taxpayers

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.ri.high_earner_tax.in_effect` | 2027-01-01 to 2100-12-31 | true | Section 1, amending R.I. Gen. Laws § 44-30-2.6 |
| `gov.contrib.states.ri.high_earner_tax.brackets[1].rate` | 2027+ | 0.03 (3%) | (Built into PE-US parameters) |
| `gov.contrib.states.ri.high_earner_tax.brackets[1].threshold` | 2026 base | $640,000 | (Built into PE-US parameters) |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **$426,538,301** |
| Poverty rate | 26.42% to 26.42% (0.0% change) |
| Child poverty rate | 22.65% to 22.65% (0.0% change) |
| Winners | 0.0% |
| Losers | 1.5% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | 0.00% | $0 |
| 2 | 0.00% | $0 |
| 3 | 0.00% | $0 |
| 4 | 0.00% | $0 |
| 5 | 0.00% | $0 |
| 6 | 0.00% | $0 |
| 7 | 0.00% | -$0.10 |
| 8 | 0.00% | $0 |
| 9 | 0.00% | $0 |
| 10 | -1.97% | -$16,934 |

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| RI-1 | -$1,063 | 0.0% | 2.0% | 0.0% |
| RI-2 | -$1,092 | 0.0% | 2.0% | 0.0% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "_use_reform": "ri_high_earner_tax",
  "gov.contrib.states.ri.high_earner_tax.in_effect": {
    "2027-01-01.2100-12-31": true
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.591.1`
- Dataset: `policyengine-us-data 1.48.0`
- Computed: 2026-03-19T14:23:11.082061+00:00

### Data quality notes
- PE estimate ($426M) is 2.2x higher than external estimates (~$190M). This discrepancy should be investigated before publishing.
- The CPS sample for Rhode Island is relatively small, which may affect estimates for ultra-high earners.
- External estimates may use state tax return data which is more accurate for this income range.