### PR TITLE
Bill review: Eliminates the individual income tax (MO)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -61,6 +61,7 @@ const descriptions = {
 
   // Missouri
   "mo-sb458": "Replaces Missouri's graduated income tax brackets (0%-4.7%) with a flat 4.0% rate on all taxable income, effective January 1, 2026. Also eliminates Missouri's federal income tax deduction (\u00a7143.171), which currently allows filers to deduct 5-35% of federal taxes paid. Includes a trigger mechanism for further rate reductions toward zero contingent on a constitutional amendment (not modeled).",
+  "mo-sb1240": "Eliminates Missouri individual income tax for all tax years beginning on or after January 1, 2027, reducing rates from 2.0%-4.7% to 0%.",
 
   // Mississippi
   "ms-sb2869": "Freezes the Mississippi income tax rate at 4% permanently, reversing the HB1 (Build Up Mississippi Act) phase-out schedule that would reduce the rate to 3% by 2030 and eventually eliminate it.",


### PR DESCRIPTION
## Bill Review: Eliminates the individual income tax

**Reform ID**: `mo-sb1240`  |  **State**: MO
**Bill text**: https://www.senate.mo.gov/26info/pdf-bill/intro/SB1240.pdf
**Description**: Eliminates Missouri individual income tax for all tax years beginning on or after January 1, 2027, reducing rates from 2.0%-4.7% to 0%.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Missouri Income Tax Elimination | `gov.states.mo.tax.income.rates.brackets[0-8].rate` | Progressive rates from 2.0% to 4.7% | 0% (complete elimination) |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| Missouri Budget Project | ~$8.7 billion | Annual | [Analysis](https://mobudget.org/eliminating-income-tax-raises-taxes/) |
| MOST Policy Initiative | $8.75 billion | FY2025 | [Memo](https://mostpolicyinitiative.org/science-note/memo-state-revenue-and-tax-rates/) |

#### Back-of-envelope check
> Income tax is 60-65% of ~$13.5B general revenue = **$8-9 billion**

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$6.52B** | — | — |
| Missouri Budget Project | -$8.7B | +33% | Review needed |
| MOST Policy Initiative | -$8.75B | +34% | Review needed |
| Back-of-envelope | -$8-9B | +30% | Review needed |

**Verdict**: PE estimate is ~25-34% lower than external estimates. This is expected because:
1. CPS microdata may undercount high earners compared to state tax return data
2. External estimates may use different base year projections
3. PE uses static microsimulation; state estimates may include behavioral responses

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| gov.states.mo.tax.income.rates.brackets[0].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[1].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[2].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[3].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[4].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[5].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[6].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[7].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |
| gov.states.mo.tax.income.rates.brackets[8].rate | 2027-01-01 to 2100-12-31 | 0 (0%) | Section 143.011 RSMo |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$6,524,096,463** |
| Poverty rate | 23.59% to 23.51% (-0.32%) |
| Child poverty rate | 19.61% to 19.51% (-0.51%) |
| Winners | 62.5% |
| Losers | 0.0% |

### Decile impact
| Decile | Relative Change | Avg Benefit |
|--------|-----------------|-------------|
| 1 | +0.05% | $6 |
| 2 | +0.57% | $153 |
| 3 | +0.46% | $176 |
| 4 | +0.71% | $344 |
| 5 | +1.08% | $658 |
| 6 | +1.80% | $1,349 |
| 7 | +2.38% | $2,153 |
| 8 | +2.93% | $3,239 |
| 9 | +3.24% | $4,699 |
| 10 | +3.83% | $32,248 |

### District impacts
| District | Avg Benefit | Winners | Losers | Poverty Change |
|----------|-------------|---------|--------|----------------|
| MO-1 | $2,685 | 63% | 0% | -0.29% |
| MO-2 | $4,175 | 62% | 0% | -0.46% |
| MO-3 | $3,433 | 64% | 0% | -0.09% |
| MO-4 | $2,834 | 62% | 0% | -0.74% |
| MO-5 | $2,692 | 63% | 0% | -0.18% |
| MO-6 | $2,988 | 63% | 0% | -0.20% |
| MO-7 | $2,655 | 62% | 0% | -0.20% |
| MO-8 | $2,780 | 62% | 0% | -0.43% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.states.mo.tax.income.rates.brackets[0].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[1].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[2].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[3].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[4].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[5].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[6].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[7].rate": {
    "2027-01-01.2100-12-31": 0
  },
  "gov.states.mo.tax.income.rates.brackets[8].rate": {
    "2027-01-01.2100-12-31": 0
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.591.1`
- Dataset: `policyengine-us-data 1.48.0`
- Computed: 2026-03-19T19:06:47.056116+00:00