### PR TITLE
Bill review: Alabama HB527 Overtime Compensation Deduction (AL)

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -6,6 +6,9 @@
  */
 
 const descriptions = {
+  // Alabama
+  "al-hb527": "Alabama HB527 creates a state income tax deduction of up to $1,000 per taxpayer per year for qualified overtime compensation (the premium portion of overtime pay). Joint filers can each claim up to $1,000. The deduction is effective for tax years 2025-2027.",
+
   // Arizona
   "az-hb2636": "Replaces Arizona's 2.5% flat individual income tax with a two-bracket progressive structure: 2.5% on the first $1M of taxable income, 8% on income above $1M. Same threshold for all filing statuses. Effective TY2027.",
 

--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -7,7 +7,7 @@
 
 const descriptions = {
   // Alabama
-  "al-hb527": "Alabama HB527 creates a state income tax deduction of up to $1,000 per taxpayer per year for qualified overtime compensation (the premium portion of overtime pay). Joint filers can each claim up to $1,000. The deduction is effective for tax years 2025-2027.",
+  "al-hb527": "Alabama HB527 creates a state income tax deduction of up to $1,000 per taxpayer per year for qualified overtime compensation (the premium portion of overtime pay, per 26 U.S.C. § 225). Joint filers can each claim up to $1,000. As enrolled, the deduction covers tax years 2026-2028; this analysis models the introduced version's 2025-2027 window (same cap and definition).",
 
   // Arizona
   "az-hb2636": "Replaces Arizona's 2.5% flat individual income tax with a two-bracket progressive structure: 2.5% on the first $1M of taxable income, 8% on income above $1M. Same threshold for all filing statuses. Effective TY2027.",


### PR DESCRIPTION
## Bill Review: Alabama HB527 Overtime Compensation Deduction

**Reform ID**: `al-hb527`  |  **State**: AL
**Bill text (introduced, modeled here)**: https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB527-int.pdf
**Bill text (enrolled)**: https://alison.legislature.state.al.us/files/pdf/SearchableInstruments/2026RS/HB527-enr.pdf
**Sponsor**: Rep. James Lomax (R-Huntsville)

**Description**: Alabama HB527 creates a state income tax deduction of up to $1,000 per taxpayer per year for qualified overtime compensation (the premium portion of overtime pay, defined per 26 U.S.C. § 225). Joint filers can each claim up to $1,000, and the deduction is allowed whether or not the taxpayer itemizes.

> **Version note (takeover review, 2026-07-23):** This analysis models the introduced version (HB527-int), whose new §40-18-15(a)(29) covers tax years 2025–2027. The bill has since been **enrolled**; the enrolled text shifts the window to **tax years 2026–2028** with the same $1,000 per-taxpayer cap and § 225 definition, so annual impacts are comparable. The stored reform parameters still encode `2025-01-01.2027-12-31`; a recompute on the enrolled window is optional follow-up.

Merging this PR will publish the bill to the dashboard.

---

### What we model
| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Overtime compensation deduction switch | `gov.contrib.states.al.hb527.in_effect` | No state overtime deduction | Deduction for qualified overtime compensation (§40-18-15(a)(29)) |
| Per-taxpayer cap | `gov.contrib.states.al.hb527.cap` | N/A | $1,000 per taxpayer per year |

The sunset is encoded in the parameter periods (introduced version: through 2027-12-31; enrolled: through 2028-12-31).

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| Alabama Legislative Fiscal Office | -$37.4M | Annual | [Alabama Daily News](https://aldailynews.com/house-committee-oks-overtime-tax-deduction/) |
| Affected workers (sponsor estimate) | ~800,000 | - | Same source |

#### Back-of-envelope check
> 800,000 workers × $50 max tax savings (5% rate × $1,000 cap) = **$40M**
> This aligns closely with the fiscal note estimate of $37.4M.

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| PE (PolicyEngine) | **-$8.2M** | — | — |
| Fiscal note | -$37.4M | -78% | Review needed |
| Back-of-envelope | -$40M | -80% | Review needed |

**Verdict**: PE estimate is significantly lower than the fiscal note. This is likely due to:
1. **CPS data limitations**: The Enhanced CPS uses `hours_worked_last_week` which may not fully capture overtime work patterns
2. **Sample size**: The CPS may undercount overtime workers relative to administrative data
3. **Fiscal note methodology**: The state estimate assumes 800,000 affected workers, which may include workers not well-represented in CPS microdata

**Takeover review cross-reference (2026-07-23):** the CPS-side undercount is corroborated by PolicyEngine's populace input-coverage receipts ([populace#451](https://github.com/PolicyEngine/populace/issues/451), [populace#499](https://github.com/PolicyEngine/populace/pull/499)): the `fsla_overtime_premium` input — the same variable this reform caps — carries ~19.9M weighted overtime recipients in the certified populace exports vs Treasury's reported >29M claimant units, and national no-tax-on-overtime probes recover only ~51% of the JCX-35-25 FY2026 score. Read the PE level here as understated rather than precise; the fiscal note's -$37.4M is the better central estimate of scale.

Note: Alabama's previous unlimited overtime exemption was projected at ~$34M annually but cost more than $400M over its 18-month existence before expiring in June 2025 (per the same Alabama Daily News source) — overtime fiscal estimates carry high uncertainty in both directions.

### Parameter changes
| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.al.hb527.in_effect` | 2025-01-01 to 2027-12-31 | true | Section 40-18-15(a)(29) (introduced; enrolled: 2026–2028) |
| `gov.contrib.states.al.hb527.cap` | 2025-01-01 to 2027-12-31 | 1000 ($1,000) | Section 40-18-15(a)(29) |

### Key results
| Metric | Value |
|--------|-------|
| Revenue impact | **-$8,168,505** |
| Poverty rate | 27.95% → 27.95% (0.0%) |
| Child poverty rate | 21.67% → 21.67% (0.0%) |
| Winners | 2.3% |
| Losers | 0.0% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.contrib.states.al.hb527.in_effect": {
    "2025-01-01.2027-12-31": true
  },
  "gov.contrib.states.al.hb527.cap": {
    "2025-01-01.2027-12-31": 1000
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.591.1`
- Dataset: `1.48.0`
- Computed: 2026-03-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
