### PR TITLE
Add ui-kit Header and Footer components

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="google-site-verification" content="yPFrltKCrAwfFqVv0l2yJVPokUucON17oNFquEu_Zeg" />
-    <link rel="icon" type="image/svg+xml" href="/policyengine-favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="https://www.policyengine.org/assets/logos/policyengine/teal-square.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Track state-level tax and benefit legislation across all 50 states. See fiscal impacts, winners and losers, and district-level analysis powered by PolicyEngine microsimulation." />
     <meta property="og:title" content="2026 State Legislative Tracker | PolicyEngine" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from "react";
+import PolicyEngineHeader from "./components/PolicyEngineHeader";
+import PolicyEngineFooter from "./components/PolicyEngineFooter";
 import USMap from "./components/USMap";
 import Breadcrumb from "./components/Breadcrumb";
 import StateSearchCombobox from "./components/StateSearchCombobox";
@@ -125,47 +127,38 @@ function App() {
 
   return (
     <div className="app-shell" style={{ minHeight: "100vh" }}>
-      {/* Header */}
+      {/* PE org header */}
+      <PolicyEngineHeader />
+
+      {/* Tracker title bar + state search */}
       <header
         className="header-accent"
         style={{
           backgroundColor: colors.white,
           boxShadow: "var(--shadow-elevation-low)",
-          position: "sticky",
-          top: 0,
-          zIndex: 50,
         }}
       >
         <div className="app-header-inner" style={{ maxWidth: "1400px", margin: "0 auto", padding: `${spacing.xl} ${spacing["2xl"]}` }}>
           <div className="app-header-row" style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-            <div className="app-header-brand" style={{ display: "flex", alignItems: "center", gap: spacing.lg }}>
-              <a href="https://policyengine.org" target="_blank" rel="noopener noreferrer">
-                <img
-                  src="/policyengine-favicon.svg"
-                  alt="PolicyEngine"
-                  style={{ height: "40px", width: "auto" }}
-                />
-              </a>
-              <div>
-                <h1 style={{
-                  margin: 0,
-                  color: colors.secondary[900],
-                  fontSize: typography.fontSize["2xl"],
-                  fontWeight: typography.fontWeight.bold,
-                  fontFamily: typography.fontFamily.primary,
-                  letterSpacing: "-0.02em",
-                }}>
-                  2026 State Legislative Tracker
-                </h1>
-                <p style={{
-                  margin: "2px 0 0",
-                  color: colors.text.secondary,
-                  fontSize: typography.fontSize.sm,
-                  fontFamily: typography.fontFamily.body,
-                }}>
-                  PolicyEngine State Tax Research
-                </p>
-              </div>
+            <div>
+              <h1 style={{
+                margin: 0,
+                color: colors.secondary[900],
+                fontSize: typography.fontSize["2xl"],
+                fontWeight: typography.fontWeight.bold,
+                fontFamily: typography.fontFamily.primary,
+                letterSpacing: "-0.02em",
+              }}>
+                2026 State Legislative Tracker
+              </h1>
+              <p style={{
+                margin: "2px 0 0",
+                color: colors.text.secondary,
+                fontSize: typography.fontSize.sm,
+                fontFamily: typography.fontFamily.body,
+              }}>
+                PolicyEngine State Tax Research
+              </p>
             </div>
             <StateSearchCombobox onSelect={handleStateSelect} statesWithBills={statesWithBills} />
           </div>
@@ -338,44 +331,8 @@ function App() {
         )}
       </main>
 
-      {/* Footer */}
-      <footer style={{
-        backgroundColor: colors.secondary[900],
-        color: colors.white,
-        position: "relative",
-        overflow: "hidden",
-      }}>
-        {/* Gradient accent at top */}
-        <div style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          right: 0,
-          height: "3px",
-          background: "linear-gradient(90deg, #2C7A7B 0%, #38B2AC 50%, #0EA5E9 100%)",
-        }} />
-        <div className="app-footer-inner" style={{
-          maxWidth: "1400px",
-          margin: "0 auto",
-          padding: `${spacing["2xl"]} ${spacing["2xl"]}`,
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}>
-          <p style={{
-            margin: 0,
-            fontSize: typography.fontSize.sm,
-            fontFamily: typography.fontFamily.body,
-            color: colors.gray[400],
-          }}>
-            © {new Date().getFullYear()} PolicyEngine. Open-source tax and benefit policy simulation.
-          </p>
-          <div className="app-footer-links" style={{ display: "flex", gap: spacing.lg }}>
-            <FooterLink href="https://github.com/policyengine">GitHub</FooterLink>
-            <FooterLink href="https://policyengine.org">PolicyEngine.org</FooterLink>
-          </div>
-        </div>
-      </footer>
+      {/* PE org footer */}
+      <PolicyEngineFooter />
     </div>
   );
 }
@@ -532,29 +489,6 @@ function QuickLinkCard({ href, title, description }) {
         fontSize: typography.fontSize.sm,
         fontFamily: typography.fontFamily.body,
       }}>{description}</p>
-    </a>
-  );
-}
-
-// Footer Link Component
-function FooterLink({ href, children }) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      style={{
-        color: colors.gray[400],
-        textDecoration: "none",
-        fontSize: typography.fontSize.sm,
-        fontFamily: typography.fontFamily.body,
-        fontWeight: typography.fontWeight.medium,
-        transition: "color 0.2s ease",
-      }}
-      onMouseEnter={(e) => e.currentTarget.style.color = colors.primary[300]}
-      onMouseLeave={(e) => e.currentTarget.style.color = colors.gray[400]}
-    >
-      {children}
     </a>
   );
 }

--- a/src/components/PolicyEngineFooter.jsx
+++ b/src/components/PolicyEngineFooter.jsx
@@ -1,0 +1,206 @@
+import { colors, typography } from '../designTokens';
+
+/**
+ * PolicyEngine org footer — matches policyengine.org production footer.
+ * Adapted from keep-your-pay-act Footer.tsx.
+ *
+ * TODO: Replace this entire file with `import { Footer } from "@policyengine/ui-kit"`
+ * once ui-kit 0.4.0 is published to npm. See:
+ * - https://github.com/PolicyEngine/policyengine-ui-kit/issues/18 (build OOM blocking publish)
+ * - https://github.com/PolicyEngine/policyengine-ui-kit/issues/16 (changelog/publish pipeline)
+ */
+
+const COLORS = {
+  primary500: colors.primary[500],
+  primary600: colors.primary[600],
+  primary800: colors.primary[800],
+};
+
+const FONT = typography.fontFamily.primary;
+
+const NAV_LINKS = [
+  { href: 'https://policyengine.org/us/team', text: 'About us' },
+  { href: 'https://policyengine.org/us/donate', text: 'Donate' },
+  { href: 'https://policyengine.org/us/privacy', text: 'Privacy policy' },
+  { href: 'https://policyengine.org/us/terms', text: 'Terms and conditions' },
+];
+
+const SOCIAL_LINKS = [
+  {
+    label: 'Email',
+    href: 'mailto:hello@policyengine.org',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M22 7l-10 7L2 7" />
+      </svg>
+    ),
+  },
+  {
+    label: 'Twitter',
+    href: 'https://twitter.com/ThePolicyEngine',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z" />
+      </svg>
+    ),
+  },
+  {
+    label: 'Facebook',
+    href: 'https://www.facebook.com/PolicyEngine',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z" />
+      </svg>
+    ),
+  },
+  {
+    label: 'LinkedIn',
+    href: 'https://www.linkedin.com/company/thepolicyengine',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-4 0v7h-4v-7a6 6 0 016-6z" />
+        <rect x="2" y="9" width="4" height="12" />
+        <circle cx="4" cy="4" r="2" />
+      </svg>
+    ),
+  },
+  {
+    label: 'YouTube',
+    href: 'https://www.youtube.com/@policyengine',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M22.54 6.42a2.78 2.78 0 00-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 00-1.94 2A29 29 0 001 11.75a29 29 0 00.46 5.33A2.78 2.78 0 003.4 19.1c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 001.94-2 29 29 0 00.46-5.25 29 29 0 00-.46-5.43z" />
+        <polygon points="9.75 15.02 15.5 11.75 9.75 8.48 9.75 15.02" />
+      </svg>
+    ),
+  },
+  {
+    label: 'Instagram',
+    href: 'https://www.instagram.com/PolicyEngine/',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+        <path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37z" />
+        <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+      </svg>
+    ),
+  },
+  {
+    label: 'GitHub',
+    href: 'https://github.com/PolicyEngine',
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22" />
+      </svg>
+    ),
+  },
+];
+
+export default function PolicyEngineFooter() {
+  return (
+    <footer
+      data-testid="pe-footer"
+      style={{
+        width: '100%',
+        padding: '48px 64px',
+        background: `linear-gradient(to right, ${COLORS.primary800}, ${COLORS.primary600})`,
+        fontFamily: FONT,
+      }}
+    >
+      <div style={{ maxWidth: '1536px', margin: '0 auto', padding: '0 16px' }}>
+        <img
+          src="https://policyengine.org/assets/logos/policyengine/white.svg"
+          alt="PolicyEngine"
+          style={{ height: '52px', width: 'auto' }}
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 mt-8" style={{ gap: '48px' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', alignItems: 'flex-start' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {NAV_LINKS.map(({ href, text }) => (
+                <a
+                  key={href}
+                  href={href}
+                  rel="noopener noreferrer"
+                  style={{ color: colors.white, fontSize: '16px', textDecoration: 'none', fontFamily: FONT }}
+                >
+                  {text}
+                </a>
+              ))}
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '12px' }}>
+                {SOCIAL_LINKS.map(({ label, href, icon }) => (
+                  <a
+                    key={href}
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={label}
+                    style={{ color: colors.white }}
+                  >
+                    {icon}
+                  </a>
+                ))}
+              </div>
+              <p style={{ fontSize: '12px', color: colors.white, margin: 0, fontFamily: FONT }}>
+                &copy; {new Date().getFullYear()} PolicyEngine. All rights reserved.
+              </p>
+            </div>
+          </div>
+
+          <div style={{ paddingLeft: '24px' }}>
+            <p style={{ fontWeight: 600, color: colors.white, fontFamily: FONT, fontSize: '24px', margin: '0 0 0 0' }}>
+              Subscribe to PolicyEngine
+            </p>
+            <p style={{ fontSize: '18px', color: colors.white, fontFamily: FONT, margin: '0 0 20px 0' }}>
+              Get the latest posts delivered right to your inbox.
+            </p>
+            <div style={{ width: '80%', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <input
+                type="email"
+                placeholder="Enter your email address"
+                style={{
+                  width: '100%',
+                  height: '40px',
+                  padding: '8px 12px',
+                  borderRadius: '6px',
+                  border: '1px solid #E2E8F0',
+                  fontSize: '14px',
+                  fontFamily: FONT,
+                  boxSizing: 'border-box',
+                  backgroundColor: colors.white,
+                }}
+              />
+              <a
+                href="https://policyengine.org/us/subscribe"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '100%',
+                  height: '40px',
+                  backgroundColor: COLORS.primary500,
+                  color: colors.white,
+                  border: 'none',
+                  borderRadius: '6px',
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  fontFamily: FONT,
+                  letterSpacing: '0.05em',
+                  cursor: 'pointer',
+                  textDecoration: 'none',
+                }}
+              >
+                SUBSCRIBE
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/PolicyEngineHeader.jsx
+++ b/src/components/PolicyEngineHeader.jsx
@@ -1,0 +1,499 @@
+import { useCallback, useState, useRef, useEffect } from 'react';
+import { colors, typography } from '../designTokens';
+
+/**
+ * PolicyEngine org header — matches policyengine.org production header.
+ * Adapted from keep-your-pay-act Header.tsx with added API and Citations nav items.
+ *
+ * TODO: Replace this entire file with `import { Header } from "@policyengine/ui-kit"`
+ * once ui-kit 0.4.0 is published to npm. See:
+ * - https://github.com/PolicyEngine/policyengine-ui-kit/issues/18 (build OOM blocking publish)
+ * - https://github.com/PolicyEngine/policyengine-ui-kit/issues/16 (changelog/publish pipeline)
+ */
+
+const COLORS = {
+  primary500: colors.primary[500],
+  primary600: colors.primary[600],
+  primary700: colors.primary[700],
+  primary800: colors.primary[800],
+  textInverse: colors.text.inverse,
+  shadowLight: 'rgba(16, 24, 40, 0.05)',
+  shadowMedium: 'rgba(16, 24, 40, 0.1)',
+};
+
+const FONT = typography.fontFamily.primary;
+
+const NAV_ITEMS = [
+  { label: 'Research', href: 'https://policyengine.org/us/research' },
+  { label: 'Model', href: 'https://policyengine.org/us/model' },
+  { label: 'API', href: 'https://policyengine.org/us/api' },
+  {
+    label: 'About',
+    hasDropdown: true,
+    items: [
+      { label: 'Team', href: 'https://policyengine.org/us/team' },
+      { label: 'Supporters', href: 'https://policyengine.org/us/supporters' },
+      { label: 'Citations', href: 'https://policyengine.org/us/citations' },
+    ],
+  },
+  { label: 'Donate', href: 'https://policyengine.org/us/donate' },
+];
+
+const COUNTRIES = [
+  { id: 'us', label: 'United States' },
+  { id: 'uk', label: 'United Kingdom' },
+];
+
+const navItemStyle = {
+  color: COLORS.textInverse,
+  fontWeight: 500,
+  fontSize: '15px',
+  fontFamily: FONT,
+  textDecoration: 'none',
+  padding: '6px 14px',
+  borderRadius: '6px',
+  transition: 'background-color 0.15s ease',
+  letterSpacing: '0.01em',
+};
+
+const hoverHandlers = {
+  onMouseEnter: (e) => {
+    e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.12)';
+  },
+  onMouseLeave: (e) => {
+    e.currentTarget.style.backgroundColor = 'transparent';
+  },
+};
+
+function AppleDropdown({ items, open, onClose, align = 'center' }) {
+  const contentRef = useRef(null);
+  const [contentHeight, setContentHeight] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (open && contentRef.current) {
+      setContentHeight(contentRef.current.scrollHeight);
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+      const timer = setTimeout(() => setContentHeight(0), 250);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
+
+  if (!open && contentHeight === 0) return null;
+
+  const positionStyle =
+    align === 'right'
+      ? { right: 0, transform: visible ? 'translateY(0)' : 'translateY(-8px)' }
+      : {
+          left: '50%',
+          transform: visible
+            ? 'translateX(-50%) translateY(0)'
+            : 'translateX(-50%) translateY(-8px)',
+        };
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{ position: 'fixed', inset: 0, zIndex: 999, cursor: 'default' }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          top: '100%',
+          ...positionStyle,
+          marginTop: '10px',
+          minWidth: '220px',
+          overflow: 'hidden',
+          maxHeight: visible ? `${contentHeight}px` : '0px',
+          opacity: visible ? 1 : 0,
+          transition:
+            'max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease, transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          borderRadius: '14px',
+          background: 'linear-gradient(135deg, rgba(255,255,255,0.97), rgba(240,249,255,0.95))',
+          backdropFilter: 'blur(24px) saturate(200%)',
+          WebkitBackdropFilter: 'blur(24px) saturate(200%)',
+          boxShadow:
+            '0 20px 60px rgba(0, 0, 0, 0.15), 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 0 0 1px rgba(255, 255, 255, 0.6)',
+          zIndex: 1001,
+        }}
+      >
+        <div ref={contentRef} style={{ padding: '8px' }}>
+          {items.map((item, i) => (
+            <a
+              key={item.label}
+              href={item.href}
+              rel="noopener noreferrer"
+              onClick={() => onClose()}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                width: '100%',
+                textAlign: 'left',
+                padding: '11px 16px',
+                borderRadius: '10px',
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+                fontSize: '14px',
+                fontFamily: FONT,
+                fontWeight: 600,
+                color: COLORS.primary800,
+                textDecoration: 'none',
+                transition: 'background-color 0.12s ease, color 0.12s ease, opacity 0.3s ease',
+                transitionDelay: visible ? `${i * 50}ms` : '0ms',
+                opacity: visible ? 1 : 0,
+                lineHeight: '1.3',
+                letterSpacing: '-0.01em',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = COLORS.primary500;
+                e.currentTarget.style.color = COLORS.textInverse;
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = 'transparent';
+                e.currentTarget.style.color = COLORS.primary800;
+              }}
+            >
+              {item.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function CountrySelector() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const contentRef = useRef(null);
+  const [contentHeight, setContentHeight] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (open && contentRef.current) {
+      setContentHeight(contentRef.current.scrollHeight);
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+      const timer = setTimeout(() => setContentHeight(0), 250);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) setOpen(false);
+    }
+    function handleKey(e) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="Country selector"
+        style={{
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          padding: '6px',
+          borderRadius: '6px',
+          transition: 'background-color 0.15s ease',
+          lineHeight: 1,
+          display: 'flex',
+          alignItems: 'center',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.12)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.backgroundColor = 'transparent';
+        }}
+      >
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+          <path d="M3.6 9h16.8" />
+          <path d="M3.6 15h16.8" />
+          <path d="M11.5 3a17 17 0 0 0 0 18" />
+          <path d="M12.5 3a17 17 0 0 1 0 18" />
+        </svg>
+      </button>
+
+      {(open || contentHeight > 0) && (
+        <>
+          <div
+            onClick={() => setOpen(false)}
+            style={{ position: 'fixed', inset: 0, zIndex: 999, cursor: 'default' }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              top: '100%',
+              right: 0,
+              transform: visible ? 'translateY(0)' : 'translateY(-8px)',
+              marginTop: '10px',
+              minWidth: '220px',
+              overflow: 'hidden',
+              maxHeight: visible ? `${contentHeight}px` : '0px',
+              opacity: visible ? 1 : 0,
+              transition:
+                'max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease, transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+              borderRadius: '14px',
+              background: 'linear-gradient(135deg, rgba(255,255,255,0.97), rgba(240,249,255,0.95))',
+              backdropFilter: 'blur(24px) saturate(200%)',
+              WebkitBackdropFilter: 'blur(24px) saturate(200%)',
+              boxShadow:
+                '0 20px 60px rgba(0, 0, 0, 0.15), 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 0 0 1px rgba(255, 255, 255, 0.6)',
+              zIndex: 1001,
+            }}
+          >
+            <div ref={contentRef} style={{ padding: '8px' }}>
+              {COUNTRIES.map((country, i) => (
+                <a
+                  key={country.id}
+                  href={`https://policyengine.org/${country.id}`}
+                  rel="noopener noreferrer"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '11px 16px',
+                    borderRadius: '10px',
+                    border: 'none',
+                    background: 'transparent',
+                    cursor: 'pointer',
+                    fontSize: '14px',
+                    fontFamily: FONT,
+                    fontWeight: country.id === 'us' ? 700 : 600,
+                    color: COLORS.primary800,
+                    textDecoration: 'none',
+                    transition: 'background-color 0.12s ease, color 0.12s ease, opacity 0.3s ease',
+                    transitionDelay: visible ? `${i * 50}ms` : '0ms',
+                    opacity: visible ? 1 : 0,
+                    lineHeight: '1.3',
+                    letterSpacing: '-0.01em',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = COLORS.primary500;
+                    e.currentTarget.style.color = COLORS.textInverse;
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = 'transparent';
+                    e.currentTarget.style.color = COLORS.primary800;
+                  }}
+                >
+                  {country.label}
+                  {country.id === 'us' && (
+                    <span style={{ marginLeft: 'auto', fontSize: '12px', opacity: 0.6 }}>&#10003;</span>
+                  )}
+                </a>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function PolicyEngineHeader() {
+  const [aboutOpen, setAboutOpen] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const aboutRef = useRef(null);
+
+  useEffect(() => {
+    if (!aboutOpen) return;
+    function handleClick(e) {
+      if (aboutRef.current && !aboutRef.current.contains(e.target)) setAboutOpen(false);
+    }
+    function handleKey(e) {
+      if (e.key === 'Escape') setAboutOpen(false);
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [aboutOpen]);
+
+  return (
+    <header
+      data-testid="pe-header"
+      style={{
+        position: 'sticky',
+        top: 0,
+        padding: '8px 24px',
+        height: '58px',
+        background: `linear-gradient(to right, ${COLORS.primary800}, ${COLORS.primary600})`,
+        borderBottom: `0.5px solid ${COLORS.primary700}`,
+        boxShadow: `0px 2px 4px -1px ${COLORS.shadowLight}, 0px 4px 6px -1px ${COLORS.shadowMedium}`,
+        zIndex: 1000,
+        fontFamily: FONT,
+        width: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', height: '100%' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <a href="https://policyengine.org/us" rel="noopener noreferrer" style={{ display: 'flex', alignItems: 'center', marginRight: '12px' }}>
+            <img
+              src="https://policyengine.org/assets/logos/policyengine/white.svg"
+              alt="PolicyEngine"
+              style={{ height: '24px', width: 'auto' }}
+            />
+          </a>
+
+          <nav className="hidden lg:flex" style={{ alignItems: 'center', gap: '24px' }}>
+            {NAV_ITEMS.map((item) =>
+              item.hasDropdown ? (
+                <div key={item.label} ref={aboutRef} style={{ position: 'relative' }}>
+                  <button
+                    type="button"
+                    onClick={() => setAboutOpen((prev) => !prev)}
+                    style={{
+                      ...navItemStyle,
+                      background: 'transparent',
+                      border: 'none',
+                      cursor: 'pointer',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                    }}
+                    {...hoverHandlers}
+                  >
+                    <span>{item.label}</span>
+                    <svg
+                      width="15"
+                      height="15"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="white"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                      style={{
+                        opacity: 0.7,
+                        transition: 'transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
+                        transform: aboutOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+                      }}
+                    >
+                      <polyline points="6 9 12 15 18 9" />
+                    </svg>
+                  </button>
+                  <AppleDropdown
+                    items={item.items}
+                    open={aboutOpen}
+                    onClose={() => setAboutOpen(false)}
+                  />
+                </div>
+              ) : (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  rel="noopener noreferrer"
+                  style={navItemStyle}
+                  {...hoverHandlers}
+                >
+                  {item.label}
+                </a>
+              ),
+            )}
+          </nav>
+        </div>
+
+        <div className="hidden lg:flex" style={{ alignItems: 'center' }}>
+          <CountrySelector />
+        </div>
+
+        <div className="flex lg:hidden" style={{ alignItems: 'center', gap: '12px' }}>
+          <CountrySelector />
+          <button
+            type="button"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label="Toggle navigation"
+            style={{ padding: '4px', borderRadius: '4px', background: 'transparent', border: 'none', cursor: 'pointer' }}
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {mobileOpen && (
+        <>
+          <div
+            style={{ position: 'fixed', inset: 0, backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 1001 }}
+            onClick={() => setMobileOpen(false)}
+          />
+          <div style={{
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            width: '300px',
+            height: '100vh',
+            backgroundColor: COLORS.primary600,
+            zIndex: 1002,
+            padding: '16px 24px',
+            fontFamily: FONT,
+          }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+              <span style={{ color: COLORS.textInverse, fontWeight: 700, fontSize: '16px' }}>Menu</span>
+              <button
+                onClick={() => setMobileOpen(false)}
+                style={{ background: 'transparent', border: 'none', cursor: 'pointer' }}
+                aria-label="Close menu"
+              >
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              {NAV_ITEMS.map((item) =>
+                item.hasDropdown ? (
+                  <div key={item.label}>
+                    <span style={{ color: COLORS.textInverse, fontWeight: 500, fontSize: '14px', display: 'block', marginBottom: '4px', fontFamily: FONT }}>
+                      {item.label}
+                    </span>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', paddingLeft: '12px' }}>
+                      {item.items.map((sub) => (
+                        <a key={sub.label} href={sub.href} rel="noopener noreferrer" style={{ color: COLORS.textInverse, textDecoration: 'none', fontWeight: 400, fontSize: '14px', fontFamily: FONT }}>
+                          {sub.label}
+                        </a>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <a key={item.label} href={item.href} rel="noopener noreferrer" style={{ color: COLORS.textInverse, textDecoration: 'none', fontWeight: 500, fontSize: '14px', display: 'block', fontFamily: FONT }}>
+                    {item.label}
+                  </a>
+                ),
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </header>
+  );
+}

--- a/src/components/reform/ChartExportWrapper.jsx
+++ b/src/components/reform/ChartExportWrapper.jsx
@@ -2,7 +2,7 @@ import { useRef, useCallback } from "react";
 import { toPng } from "html-to-image";
 import { colors, typography, spacing } from "../../designTokens";
 
-const PE_LOGO_URL = "/policyengine-logo.svg";
+const PE_LOGO_URL = "https://www.policyengine.org/assets/logos/policyengine/teal.svg";
 
 const DownloadIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">


### PR DESCRIPTION
## Summary

Adds PE org header and footer to the state legislative tracker, matching policyengine.org production.

app-v2 PR #914 (already merged) switched the tracker from iframe to Vercel rewrite to fix deep link 404s. That removed the website's header/footer wrapper around the tracker. This PR adds the header/footer directly to the tracker app to restore the navigation chrome.

### Header (commit 1)
- Teal gradient header with nav links: Research, Model, API, About (Team/Supporters/Citations dropdown), Donate
- Country selector with globe icon matching production exactly
- Mobile hamburger menu
- Tracker title sub-bar with state search combobox preserved below the PE header
- Favicon updated to absolute URL (policyengine.org hosted asset)
- Chart export watermark updated to absolute URL
- Uses tracker's own `designTokens.js` — no new dependencies

### Footer (commit 2 — separate for easy revert)
- Teal gradient footer matching production: logo, nav links, social icons, subscribe form, copyright
- Replaces old dark footer bar and removes unused FooterLink component
- Uses tracker's own `designTokens.js`

### Approach
Hand-rolled components — no ui-kit dependency. ui-kit 0.4.0 isn't published ([build OOM](https://github.com/PolicyEngine/policyengine-ui-kit/issues/18)), and 0.3.1's Header has a different API. Both files have TODO comments linking to ui-kit issues for future replacement.

### Verified locally
- Production build (`npm run build`) passes
- Tested through app-v2 Vercel rewrite locally (tracker prod build on port 4200, website dev server on port 3000)
- Deep links work: `/us/state-legislative-tracker/MN/mn-hf4621` loads correct bill page
- PE header renders with correct nav, dropdown, country selector, mobile menu
- PE footer renders with logo, links, social icons, subscribe form
- Tracker functionality (map, states, bills, sidebar, breadcrumbs) unaffected

## Test plan

- [x] `npm run build` passes
- [x] Deep links work through rewrite
- [x] PE header shows with correct nav links and country selector
- [x] About dropdown opens with Team, Supporters, Citations
- [x] Footer shows logo, nav links, social icons, subscribe form
- [ ] Merge → auto-deploys to Modal → verify on production policyengine.org/us/state-legislative-tracker