### PR TITLE
Add daily bill refresh workflow

### DIFF
--- a/.github/workflows/bill-refresh.yml
+++ b/.github/workflows/bill-refresh.yml
@@ -1,0 +1,36 @@
+name: Daily Bill Refresh
+
+on:
+  schedule:
+    # 11:00 UTC = 7:00 AM ET (runs before workday starts)
+    - cron: "0 11 * * *"
+  workflow_dispatch: # Allow manual trigger from GitHub UI
+
+jobs:
+  refresh-and-discover:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests supabase
+
+      - name: Refresh bill statuses from OpenStates
+        env:
+          OPENSTATES_API_KEY: ${{ secrets.OPENSTATES_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        run: python scripts/refresh_bill_status.py --limit 100
+
+      - name: Discover new bills from OpenStates
+        env:
+          OPENSTATES_API_KEY: ${{ secrets.OPENSTATES_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        run: python scripts/openstates_monitor.py


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs daily at 7am ET (11:00 UTC)
- Refreshes the top 100 tracked bill statuses via OpenStates API
- Discovers new bills across all states using 11 keyword queries
- Supports manual trigger via `workflow_dispatch`

## Setup required
Add these repository secrets before merging:
- `OPENSTATES_API_KEY`
- `SUPABASE_URL`
- `SUPABASE_KEY`

## Test plan
- [ ] Add the 3 secrets in repo settings
- [ ] After merge, manually trigger the workflow from the Actions tab to verify
- [ ] Confirm bill statuses update in Supabase and new bills are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)