### PR TITLE
Bill review: HI SB3125 HD1

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -33,6 +33,7 @@ const descriptions = {
 
   // Hawaii
   "hi-hb2306": "Freezes Hawaii income tax bracket thresholds at 2025 levels, increases top three marginal rates by 1pp (9%→10%, 10%→11%, 11%→12%), expands the child and dependent care credit (50%-5% match up to $160k AGI vs current 25%-15% up to $50k), and extends Act 163 enhanced credits (40% EITC, expanded CDCC limits, food/excise credit) through 2033. Effective for taxable years beginning after December 31, 2026.",
+  "hi-sb3125-hd1": "Freezes Hawaii income tax bracket thresholds at 2025 levels, increases top three marginal rates by 1pp (9%→10%, 10%→11%, 11%→12%), expands the child and dependent care credit (50%-5% match up to $160k AGI vs current 25%-15% up to $50k), and extends Act 163 enhanced credits (40% EITC, expanded CDCC limits, food/excise credit) through 2032. Effective for taxable years beginning after December 31, 2026.",
 
   // Idaho
   "id-sb1450": "Extends Idaho's $205 nonrefundable child tax credit indefinitely by removing the January 1, 2026 sunset date.",


### PR DESCRIPTION
## Bill Review: HI SB3125 HD1 - Relating to Income Tax

**Reform ID**: `hi-sb3125-hd1`  |  **State**: HI
**Bill text**: https://www.capitol.hawaii.gov/sessions/session2026/bills/SB3125_HD1_.HTM
**Description**: Freezes Hawaii income tax bracket thresholds at 2025 levels, increases top three marginal rates by 1pp (9%→10%, 10%→11%, 11%→12%), expands the child and dependent care credit (50%-5% match up to $160k AGI vs current 25%-15% up to $50k), and extends Act 163 enhanced credits (40% EITC, expanded CDCC limits, food/excise credit) through 2032. Effective for taxable years beginning after December 31, 2026.

Merging this PR will publish the bill to the dashboard.

---

### What we model

| Provision | Current | Proposed |
|-----------|---------|----------|
| Bracket thresholds | Scheduled increases in 2027 and 2029 | Frozen at 2025 levels |
| Top marginal rates | 9%, 10%, 11% | 10%, 11%, 12% |
| CDCC match | 25%-15% (AGI up to $50k) | 50%-5% (AGI up to $160k) |
| Act 163 credits | Sunset Dec 31, 2027 | Extended to Dec 31, 2032 |

**Note**: Part II of the bill (renewable energy tax credits) is not modeled per user instruction.

### Validation

This bill is **functionally identical** to HI HB2306 HD1 for the income tax provisions we model. The reform parameters are copied from the existing HB2306 analysis.

### Multi-Year Results Summary

| Year | Revenue Impact | Poverty Change | Child Poverty Change | Winners | Losers |
|------|----------------|----------------|---------------------|---------|--------|
| 2027 | +$396.2M | +0.39% | +0.31% | 2.9% | 64.3% |
| 2028 | +$270.2M | -2.04% | -3.30% | 37.5% | 55.2% |
| 2029 | +$592.0M | -1.85% | -3.72% | 34.0% | 61.3% |
| 2030 | +$620.4M | -1.02% | -2.58% | 33.5% | 62.2% |
| 2031 | +$643.3M | -1.70% | -3.22% | 33.8% | 61.8% |
| 2032 | +$679.1M | -1.83% | -3.04% | 32.9% | 62.8% |
| 2033 | +$852.2M | +0.37% | +0.29% | 1.5% | 68.4% |

**Key observations**:
- 2027: Only income tax rate increases take effect (threshold freeze, rate hikes). Credits unchanged → net revenue increase, slight poverty increase.
- 2028-2032: Enhanced EITC (40%), expanded CDCC, and food/excise credits offset higher taxes for lower/middle income → poverty decreases, more winners.
- 2033: Act 163 credits sunset → revert to lower EITC (20%), lower food credit. Net impact is revenue increase and slight poverty increase.

### Versions
- PolicyEngine US: `1.626.1`
- Dataset: `1.48.0`
- Computed: 2026-04-14

🤖 Generated with [Claude Code](https://claude.ai/code)