### PR TITLE
Add GA4 analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,48 @@
       gtag('js', new Date());
       gtag('config', 'G-91M4529HE7', { tool_name: 'state-legislative-tracker' });
     </script>
+    <script>
+    (function() {
+      var TOOL_NAME = 'state-legislative-tracker';
+      if (typeof window === 'undefined' || !window.gtag) return;
+
+      var scrollFired = {};
+      window.addEventListener('scroll', function() {
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        var pct = Math.floor((window.scrollY / docHeight) * 100);
+        [25, 50, 75, 100].forEach(function(m) {
+          if (pct >= m && !scrollFired[m]) {
+            scrollFired[m] = true;
+            window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+          }
+        });
+      }, { passive: true });
+
+      [30, 60, 120, 300].forEach(function(sec) {
+        setTimeout(function() {
+          if (document.visibilityState !== 'hidden') {
+            window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+          }
+        }, sec * 1000);
+      });
+
+      document.addEventListener('click', function(e) {
+        var link = e.target && e.target.closest ? e.target.closest('a') : null;
+        if (!link || !link.href) return;
+        try {
+          var url = new URL(link.href, window.location.origin);
+          if (url.hostname && url.hostname !== window.location.hostname) {
+            window.gtag('event', 'outbound_click', {
+              url: link.href,
+              target_hostname: url.hostname,
+              tool_name: TOOL_NAME
+            });
+          }
+        } catch (err) {}
+      });
+    })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -24,12 +24,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <title>2026 State Legislative Tracker | PolicyEngine US</title>
     <!-- Google Analytics (GA4) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2YHG89FY0N"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-91M4529HE7', { tool_name: 'state-legislative-tracker' });
+      gtag('config', 'G-2YHG89FY0N', { tool_name: 'state-legislative-tracker' });
     </script>
     <script>
     (function() {

--- a/index.html
+++ b/index.html
@@ -23,6 +23,14 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <title>2026 State Legislative Tracker | PolicyEngine US</title>
+    <!-- Google Analytics (GA4) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-91M4529HE7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-91M4529HE7', { tool_name: 'state-legislative-tracker' });
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds GA4 tracking (shared org ID `G-2YHG89FY0N`) with `tool_name=state-legislative-tracker` on all events so this tool rolls up into the PolicyEngine-wide analytics dashboard.
- Events: pageview, `scroll_depth` (25/50/75/100%), `time_on_tool` (30/60/120/300s, visible tabs only), `outbound_click` (any link off this host).
- Note: This repo also uses PostHog; GA4 runs alongside without affecting PostHog.

## Follow-ups (out of scope)
- Tool-specific events: calculator submit, input changes, share/embed CTAs

## Test plan
- [ ] `gtag/js` loads in browser network tab
- [ ] `tool_name: state-legislative-tracker` appears in GA4 DebugView on pageview
- [ ] Scroll to bottom: `scroll_depth` events fire at 25/50/75/100
- [ ] Wait 30s+ on the page: `time_on_tool` events fire
- [ ] Click an external link: `outbound_click` event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)