### PR TITLE
Bill review: MN HF4890 — fifth income tax bracket + expanded Child Credit

### DIFF
--- a/src/data/analysisDescriptions.js
+++ b/src/data/analysisDescriptions.js
@@ -62,6 +62,7 @@ const descriptions = {
   "mn-hf154": "Reduces Minnesota's first-tier individual income tax rate from 5.35% to 2.8%, a 2.55 percentage point cut affecting all filing statuses. Also rebases statutory bracket thresholds to 2025 inflation-adjusted values (no real-world threshold change). Effective for tax years beginning after December 31, 2024.",
   "mn-hf2197-ctc-wfc-marriage-penalty": "Increases CTC phaseout threshold for joint filers to $75,000 and other filers to $37,500, eliminates WFC for childless adults.",
   "mn-hf2502-ctc-marriage-penalty": "Increases child credit phaseout threshold for joint filers from $35,000 to $63,900 to eliminate marriage penalty.",
+  "mn-hf4890": "Minnesota HF4890 adds a fifth individual income tax bracket at 10.15% applying to high-income filers ($1,000,000 joint, $600,000 single, $800,000 head of household), restructures the four existing brackets, and increases the Minnesota Child Credit to $2,000 per qualifying child. Effective tax year 2026.",
 
   // Missouri
   "mo-sb458": "Replaces Missouri's graduated income tax brackets (0%-4.7%) with a flat 4.0% rate on all taxable income, effective January 1, 2026. Also eliminates Missouri's federal income tax deduction (\u00a7143.171), which currently allows filers to deduct 5-35% of federal taxes paid. Includes a trigger mechanism for further rate reductions toward zero contingent on a constitutional amendment (not modeled).",


### PR DESCRIPTION
## Bill Review: Establishing a fifth individual income tax bracket and expanding the Minnesota Child Credit

**Reform ID**: `mn-hf4890`  |  **State**: MN  |  **Type**: bill
**Bill text**: https://www.revisor.mn.gov/bills/94/2026/0/HF/4890/versions/0/
**PolicyEngine-US implementation**: https://github.com/PolicyEngine/policyengine-us/pull/8009 (merged, released in v1.650.0+)

**Description**: Minnesota HF4890 adds a fifth individual income tax bracket at 10.15% applying to high-income filers ($1,000,000 joint, $600,000 single, $800,000 head of household), restructures the four existing brackets, and increases the Minnesota Child Credit to $2,000 per qualifying child.

Merging this PR will publish the bill to the dashboard.

---

### What we model

| Provision | Parameter | Current | Proposed |
|-----------|-----------|---------|----------|
| Minnesota Individual Income Tax Rate Schedule | `gov.contrib.states.mn.hf4890.in_effect` | Four brackets: 5.35%, 6.8%, 7.85%, 9.85% | Five brackets: 5.35%, 6.8%, 7.85%, 9.85%, 10.15% |
| Minnesota Child Credit Amount | `gov.states.mn.tax.income.credits.cwfc.ctc.amount` | $1,750 per qualifying child | $2,000 per qualifying child |

### Validation

#### External estimates
| Source | Estimate | Period | Link |
|--------|----------|--------|------|
| Minnesota Department of Revenue — fiscal note | *Not yet published* | — | — |
| MN DOR analog (HF1938, 2023 — identical thresholds, 10.85% rate) | ~$265M/year raised | annual | [MN House Session Daily](https://www.house.mn.gov/SessionDaily/Story/15875) |
| MN DOR analog (HF2591, 2025 — HITS model methodology) | ~$278M FY2026 at 10.91% rate on $1.67M MFJ threshold | FY2026 | [House fiscal analysis PDF](https://www.house.mn.gov/comm/docs/U4n-i1wnfkm3T5PcJnaj8Q.pdf) |
| ITEP (2023 parallel package) | ~$1B biennium (broader House tax package) | biennium | [ITEP analysis](https://itep.org/minnesota-lawmakers-re-envision-state-tax-system-to-center-equity/) |

*No official fiscal note has been published for HF4890. The bill was introduced 2026-04-09.*

#### Back-of-envelope check

> **Fifth tier (revenue raiser):** 0.30 percentage points (10.15% − 9.85% current top rate) on MN taxable income above $1M joint / $600K single / $800K head-of-household. Scaling from MN DOR's HF1938 (2023) estimate of ~$265M/yr at +1.00pp rate above the same thresholds → **~$79M/yr raised** at +0.30pp.
>
> **Child credit expansion (revenue cost):** Per-child maximum rises $1,750 → $2,000 (+14.3%). TY2023 young-child-credit cost was ~$558M → **~$80M/yr cost**.
>
> **Net:** +$79M − $80M ≈ **roughly revenue-neutral** (−$1M to +$17M/yr).

#### PE vs External comparison
| Source | Estimate | vs PE | Difference |
|--------|----------|-------|------------|
| **PolicyEngine** | **$31.2M** | — | — |
| Back-of-envelope | ~$0 to +$17M | +$14M to +$31M | Same sign, same order of magnitude (Excellent) |
| MN DOR fiscal note | *Not yet published* | — | — |

**Verdict**: PE produces a net revenue raise of **$31.2M/year**, consistent with the back-of-envelope (~revenue-neutral to slightly positive). The fifth-tier revenue is partially offset by the CTC expansion, matching the bill's structure. Re-validate once an official MN DOR fiscal note publishes.

Discrepancy sources: PE uses the Enhanced CPS microdata for Minnesota, while the MN DOR HITS model uses a stratified sample of actual MN individual income tax returns. CPS top-coding understates the number and income of $1M+ filers, potentially understating fifth-tier revenue relative to MN DOR estimates based on return-level data.

### Parameter changes

| Parameter | Period | Value | Bill Reference |
|-----------|--------|-------|----------------|
| `gov.contrib.states.mn.hf4890.in_effect` | 2026-01-01.2100-12-31 | True | Section 1, amending Minn. Stat. 2025 Supp. §290.06, subd. 2c |
| `gov.states.mn.tax.income.credits.cwfc.ctc.amount` | 2026-01-01.2100-12-31 | 2000 | Section 3, amending Minn. Stat. 2024 §290.0661, subd. 3 |

### Key results

| Metric | Value |
|--------|-------|
| Revenue impact | **$31.2M** |
| Households modeled | 2,247,524 |
| Poverty rate | 24.86% → 24.62% (-0.23%) |
| Child poverty rate | 22.82% → 22.24% (-0.57%) |
| Winners | 23.18% |
| Losers | 0.38% |
| No change | 76.45% |

### Decile impact

| Decile | Avg Benefit | Relative Change |
|--------|-------------|-----------------|
| 1 | $22 | 0.262% |
| 2 | $60 | 0.232% |
| 3 | $141 | 0.327% |
| 4 | $159 | 0.278% |
| 5 | $113 | 0.155% |
| 6 | $50 | 0.055% |
| 7 | $25 | 0.022% |
| 8 | $21 | 0.014% |
| 9 | $5 | 0.002% |
| 10 | -$819 | -0.065% |

Deciles 1–9 gain on average (driven by the expanded Minnesota Child Credit); decile 10 loses an average of $819/year as the new 10.15% fifth tier applies to income above $600K–$1M.

### District impacts

| District | Avg Benefit | Total Benefit | Winners | Losers | Child Poverty |
|----------|-------------|---------------|---------|--------|---------------|
| MN-1 — Congressional District 1 | $-35 | -$9.9M | 23% | 1% | -4.59% |
| MN-2 — Congressional District 2 | $-32 | -$9.0M | 23% | 1% | -2.47% |
| MN-3 — Congressional District 3 | $11 | $3.0M | 25% | 0% | -1.02% |
| MN-4 — Congressional District 4 | $4 | $1.1M | 23% | 0% | -3.53% |
| MN-5 — Congressional District 5 | $-12 | -$3.4M | 23% | 0% | -2.31% |
| MN-6 — Congressional District 6 | $-4 | -$1.2M | 22% | 0% | -0.82% |
| MN-7 — Congressional District 7 | $-42 | -$11.9M | 24% | 0% | -3.44% |
| MN-8 — Congressional District 8 | $1 | $260K | 23% | 0% | -3.06% |

<details><summary>Reform parameters JSON</summary>

```json
{
  "gov.contrib.states.mn.hf4890.in_effect": {
    "2026-01-01.2100-12-31": true
  },
  "gov.states.mn.tax.income.credits.cwfc.ctc.amount": {
    "2026-01-01.2100-12-31": 2000
  }
}
```

</details>

### Versions
- PolicyEngine US: `1.653.3`
- Dataset: `policyengine-us-data` `1.48.0`
- Computed: 2026-04-20T15:00:37.258171+00:00
