### PR TITLE
Align activity sidebar with map; add multi-select state/stage filters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, lazy, Suspense } from "react";
+import { useState, useEffect, useCallback, useMemo, useLayoutEffect, useRef, lazy, Suspense } from "react";
 import USMap from "./components/USMap";
 import Breadcrumb from "./components/Breadcrumb";
 import StateSearchCombobox from "./components/StateSearchCombobox";
@@ -50,6 +50,19 @@ function App() {
   const { statesWithBills, getBillsForState } = useData();
   const [selectedState, setSelectedState] = useState(() => parsePath().state);
   const [billId, setBillId] = useState(() => parsePath().billId);
+  const mapCardRef = useRef(null);
+  const [mapCardHeight, setMapCardHeight] = useState(null);
+
+  useLayoutEffect(() => {
+    const el = mapCardRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (mapCardRef.current) setMapCardHeight(mapCardRef.current.offsetHeight);
+    });
+    observer.observe(el);
+    setMapCardHeight(el.offsetHeight);
+    return () => observer.disconnect();
+  }, [selectedState, billId]);
 
   const activeStates = useMemo(
     () =>
@@ -244,97 +257,93 @@ function App() {
               gridTemplateColumns: "minmax(0, 1fr) 340px",
               gap: spacing.lg,
               alignItems: "start",
-              marginBottom: spacing["2xl"],
+              marginBottom: spacing.lg,
             }}>
-              <div style={{ display: "flex", flexDirection: "column", gap: spacing.lg }}>
-                <div
-                  className="app-map-card animate-fade-in-up"
-                  style={{
-                    backgroundColor: colors.white,
-                    borderRadius: spacing.radius["2xl"],
-                    boxShadow: "var(--shadow-elevation-low)",
-                    border: `1px solid ${colors.border.light}`,
-                    padding: spacing.lg,
-                    transition: "box-shadow 0.3s ease",
-                  }}
-                >
-                  <div className="app-map-layout" style={{ display: "flex", alignItems: "flex-start" }}>
-                    <div style={{ flex: 1 }}>
-                      <USMap
-                        selectedState={selectedState}
-                        onStateSelect={handleStateSelect}
-                      />
-                    </div>
-                    <div className="app-map-legend" style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: spacing.sm,
-                      paddingLeft: spacing.lg,
-                      marginLeft: spacing.lg,
-                      borderLeft: `1px solid ${colors.border.light}`,
-                      alignSelf: "center",
-                      flexShrink: 0,
-                    }}>
-                      <LegendItem color={mapColors.inSession} label="In Session" />
-                      <LegendItem color={mapColors.upcoming} label="Upcoming" />
-                      <LegendItem color={mapColors.ended} label="Ended" />
-                      <LegendItem color={mapColors.noSession} label="No 2026 Session" />
-                    </div>
+              <div
+                ref={mapCardRef}
+                className="app-map-card animate-fade-in-up"
+                style={{
+                  backgroundColor: colors.white,
+                  borderRadius: spacing.radius["2xl"],
+                  boxShadow: "var(--shadow-elevation-low)",
+                  border: `1px solid ${colors.border.light}`,
+                  padding: spacing.lg,
+                  transition: "box-shadow 0.3s ease",
+                }}
+              >
+                <div className="app-map-layout" style={{ display: "flex", alignItems: "flex-start" }}>
+                  <div style={{ flex: 1 }}>
+                    <USMap
+                      selectedState={selectedState}
+                      onStateSelect={handleStateSelect}
+                    />
                   </div>
+                  <div className="app-map-legend" style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: spacing.sm,
+                    paddingLeft: spacing.lg,
+                    marginLeft: spacing.lg,
+                    borderLeft: `1px solid ${colors.border.light}`,
+                    alignSelf: "center",
+                    flexShrink: 0,
+                  }}>
+                    <LegendItem color={mapColors.inSession} label="In Session" />
+                    <LegendItem color={mapColors.upcoming} label="Upcoming" />
+                    <LegendItem color={mapColors.ended} label="Ended" />
+                    <LegendItem color={mapColors.noSession} label="No 2026 Session" />
+                  </div>
+                </div>
 
-                  {activeStates.length > 0 && (
-                    <div style={{
-                      marginTop: spacing.lg,
-                      paddingTop: spacing.md,
-                      borderTop: `1px solid ${colors.border.light}`,
+                {activeStates.length > 0 && (
+                  <div style={{
+                    marginTop: spacing.lg,
+                    paddingTop: spacing.md,
+                    borderTop: `1px solid ${colors.border.light}`,
+                  }}>
+                    <h3 style={{
+                      margin: `0 0 ${spacing.md}`,
+                      color: colors.text.tertiary,
+                      fontSize: typography.fontSize.xs,
+                      fontWeight: typography.fontWeight.semibold,
+                      fontFamily: typography.fontFamily.primary,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.5px",
+                      textAlign: "center",
                     }}>
-                      <h3 style={{
-                        margin: `0 0 ${spacing.md}`,
-                        color: colors.text.tertiary,
-                        fontSize: typography.fontSize.xs,
-                        fontWeight: typography.fontWeight.semibold,
-                        fontFamily: typography.fontFamily.primary,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.5px",
-                        textAlign: "center",
-                      }}>
-                        States with Published Analysis
-                      </h3>
-                      <RegionChips states={activeStates} onSelect={handleStateSelect} />
-                    </div>
-                  )}
-                </div>
-
-                <div className="animate-fade-in-up app-recent-activity-mobile">
-                  <RecentActivitySidebar onStateSelect={handleStateSelect} onBillSelect={handleBillSelect} />
-                </div>
-
-                <div className="app-quick-links" style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(3, 1fr)",
-                  gap: spacing.md,
-                }}>
-                  <QuickLinkCard
-                    href="https://policyengine.org/us/research"
-                    title="Full Research Library"
-                    description="Browse all PolicyEngine state and federal research"
-                  />
-                  <QuickLinkCard
-                    href="https://app.policyengine.org/us/reports"
-                    title="Build a Reform"
-                    description="Model your own tax policy reforms"
-                  />
-                  <QuickLinkCard
-                    href="mailto:hello@policyengine.org?subject=State Legislative Analysis Request"
-                    title="Get in Contact"
-                    description="Get custom analysis for your state's legislation"
-                  />
-                </div>
+                      States with Published Analysis
+                    </h3>
+                    <RegionChips states={activeStates} onSelect={handleStateSelect} />
+                  </div>
+                )}
               </div>
 
-              <div className="animate-fade-in-up app-sidebar-sticky app-recent-activity-desktop" style={{ position: "sticky", top: "80px" }}>
+              <div className="animate-fade-in-up app-activity-cell" style={{ height: mapCardHeight ? `${mapCardHeight}px` : undefined }}>
                 <RecentActivitySidebar onStateSelect={handleStateSelect} onBillSelect={handleBillSelect} />
               </div>
+            </div>
+
+            <div className="app-quick-links" style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: spacing.md,
+              marginBottom: spacing["2xl"],
+            }}>
+              <QuickLinkCard
+                href="https://policyengine.org/us/research"
+                title="Full Research Library"
+                description="Browse all PolicyEngine state and federal research"
+              />
+              <QuickLinkCard
+                href="https://app.policyengine.org/us/reports"
+                title="Build a Reform"
+                description="Model your own tax policy reforms"
+              />
+              <QuickLinkCard
+                href="mailto:hello@policyengine.org?subject=State Legislative Analysis Request"
+                title="Get in Contact"
+                description="Get custom analysis for your state's legislation"
+              />
             </div>
           </>
         )}

--- a/src/components/BillActivityFeed.jsx
+++ b/src/components/BillActivityFeed.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef, useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
 import { supabase } from "../lib/supabase";
 import { useData } from "../context/DataContext";
 import { colors, typography, spacing } from "../designTokens";
@@ -108,6 +109,211 @@ function TimeAgo({ dateStr }) {
   );
 }
 
+// ============== MultiSelectPopover ==============
+
+function MultiSelectPopover({ label, options, values, onChange, searchable = false, align = "left" }) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [anchorRect, setAnchorRect] = useState(null);
+  const triggerRef = useRef(null);
+  const popoverRef = useRef(null);
+
+  const selectedCount = values.length;
+  const buttonLabel = selectedCount === 0
+    ? `All ${label.toLowerCase()}`
+    : selectedCount === 1
+      ? values[0]
+      : `${selectedCount} ${label.toLowerCase()}`;
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+    setAnchorRect(triggerRef.current.getBoundingClientRect());
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e) => {
+      if (triggerRef.current?.contains(e.target)) return;
+      if (popoverRef.current?.contains(e.target)) return;
+      setOpen(false);
+    };
+    const onKey = (e) => { if (e.key === "Escape") setOpen(false); };
+    const onScrollOrResize = () => {
+      if (triggerRef.current) setAnchorRect(triggerRef.current.getBoundingClientRect());
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      document.removeEventListener("mousedown", onDocMouseDown);
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [open]);
+
+  const filteredOptions = useMemo(() => {
+    if (!query) return options;
+    const q = query.toLowerCase();
+    return options.filter((o) => o.toLowerCase().includes(q));
+  }, [options, query]);
+
+  const toggle = (opt) => {
+    if (values.includes(opt)) onChange(values.filter((v) => v !== opt));
+    else onChange([...values, opt]);
+  };
+
+  const isActive = selectedCount > 0;
+
+  const triggerStyle = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+    padding: "4px 8px",
+    border: `1px solid ${isActive ? colors.primary[300] : colors.border.light}`,
+    borderRadius: spacing.radius.md,
+    backgroundColor: isActive ? colors.primary[50] : colors.white,
+    color: isActive ? colors.primary[700] : colors.secondary[900],
+    fontSize: "11px",
+    fontFamily: typography.fontFamily.body,
+    fontWeight: typography.fontWeight.medium,
+    cursor: "pointer",
+    transition: "background-color 0.15s, border-color 0.15s",
+    minWidth: 0,
+  };
+
+  let popoverStyle = null;
+  if (anchorRect) {
+    const WIDTH = 220;
+    const left = align === "right"
+      ? Math.max(8, anchorRect.right - WIDTH)
+      : Math.min(window.innerWidth - WIDTH - 8, anchorRect.left);
+    popoverStyle = {
+      position: "fixed",
+      top: anchorRect.bottom + 4,
+      left,
+      width: WIDTH,
+      maxHeight: "min(320px, 60vh)",
+      display: "flex",
+      flexDirection: "column",
+      backgroundColor: colors.white,
+      borderRadius: spacing.radius.lg,
+      border: `1px solid ${colors.border.light}`,
+      boxShadow: "var(--shadow-elevation-medium, 0 8px 24px rgba(0,0,0,0.12))",
+      zIndex: 1000,
+      overflow: "hidden",
+    };
+  }
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        style={triggerStyle}
+      >
+        <span style={{ flex: 1, textAlign: "left", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {buttonLabel}
+        </span>
+        <span style={{ opacity: 0.6, fontSize: "9px" }}>▾</span>
+      </button>
+      {open && popoverStyle && createPortal(
+        <div ref={popoverRef} style={popoverStyle} role="listbox">
+          {searchable && (
+            <div style={{ padding: "8px", borderBottom: `1px solid ${colors.border.light}` }}>
+              <input
+                type="text"
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={`Search ${label.toLowerCase()}…`}
+                style={{
+                  width: "100%",
+                  padding: "4px 8px",
+                  border: `1px solid ${colors.border.light}`,
+                  borderRadius: spacing.radius.sm,
+                  fontSize: "12px",
+                  fontFamily: typography.fontFamily.body,
+                  outline: "none",
+                }}
+              />
+            </div>
+          )}
+          <div style={{ overflowY: "auto", padding: "4px 0" }}>
+            {filteredOptions.length === 0 && (
+              <div style={{
+                padding: "8px 12px",
+                color: colors.text.tertiary,
+                fontSize: "12px",
+                fontFamily: typography.fontFamily.body,
+              }}>
+                No matches.
+              </div>
+            )}
+            {filteredOptions.map((opt) => {
+              const checked = values.includes(opt);
+              return (
+                <label
+                  key={opt}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    padding: "6px 12px",
+                    cursor: "pointer",
+                    fontSize: "12px",
+                    fontFamily: typography.fontFamily.body,
+                    color: colors.secondary[900],
+                    backgroundColor: checked ? colors.primary[50] : "transparent",
+                  }}
+                  onMouseEnter={(e) => { if (!checked) e.currentTarget.style.backgroundColor = colors.gray[50]; }}
+                  onMouseLeave={(e) => { if (!checked) e.currentTarget.style.backgroundColor = "transparent"; }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggle(opt)}
+                    style={{ accentColor: colors.primary[600], cursor: "pointer" }}
+                  />
+                  <span style={{ flex: 1 }}>{opt}</span>
+                </label>
+              );
+            })}
+          </div>
+          {selectedCount > 0 && (
+            <div style={{
+              padding: "6px 12px",
+              borderTop: `1px solid ${colors.border.light}`,
+              backgroundColor: colors.background.secondary,
+            }}>
+              <button
+                type="button"
+                onClick={() => onChange([])}
+                style={{
+                  border: "none",
+                  background: "transparent",
+                  padding: 0,
+                  color: colors.primary[700],
+                  fontSize: "11px",
+                  fontFamily: typography.fontFamily.body,
+                  cursor: "pointer",
+                }}
+              >
+                Clear selection
+              </button>
+            </div>
+          )}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}
+
 // ============== Shared hook to fetch processed_bills ==============
 
 export function useProcessedBills(stateFilter) {
@@ -146,10 +352,31 @@ export function RecentActivitySidebar({ onStateSelect, onBillSelect }) {
   const { statesWithBills, research } = useData();
   const encodedStates = useMemo(() => new Set(Object.keys(statesWithBills)), [statesWithBills]);
   const [tab, setTab] = useState("analyzed"); // "recent" | "analyzed"
+  const [filterStates, setFilterStates] = useState([]);
+  const [filterStages, setFilterStages] = useState([]);
   const [actionBill, setActionBill] = useState(null);
   const [requestBill, setRequestBill] = useState(null);
 
-  const recentBills = useMemo(() => bills.slice(0, 25), [bills]);
+  const uniqueStates = useMemo(
+    () => [...new Set(bills.map((b) => b.state).filter(Boolean))].sort(),
+    [bills],
+  );
+  const uniqueStages = useMemo(
+    () => [...new Set(bills.map((b) => b.status || "Introduced").filter(Boolean))].sort(),
+    [bills],
+  );
+
+  const matchesFilters = useCallback(
+    (b) =>
+      (filterStates.length === 0 || filterStates.includes(b.state)) &&
+      (filterStages.length === 0 || filterStages.includes(b.status || "Introduced")),
+    [filterStates, filterStages],
+  );
+
+  const recentBills = useMemo(
+    () => bills.filter(matchesFilters).slice(0, 25),
+    [bills, matchesFilters],
+  );
 
   // Bills that have PE analysis (exist in research table as published bills)
   // Also build reverse lookup: "STATE:BILLNUM" -> research id for navigation
@@ -177,8 +404,9 @@ export function RecentActivitySidebar({ onStateSelect, onBillSelect }) {
         const norm = `${b.state}:${b.bill_number.replace(/\s+/g, "").replace(/^([A-Z]+)0+(\d)/, "$1$2").toUpperCase()}`;
         return analyzedBillIds.has(norm);
       })
+      .filter(matchesFilters)
       .slice(0, 25),
-    [bills, analyzedBillIds],
+    [bills, analyzedBillIds, matchesFilters],
   );
 
   const displayBills = tab === "analyzed" ? analyzedBills : recentBills;
@@ -200,7 +428,9 @@ export function RecentActivitySidebar({ onStateSelect, onBillSelect }) {
     );
   }
 
-  if (!recentBills.length) return null;
+  if (!bills.length) return null;
+
+  const filtersActive = filterStates.length > 0 || filterStages.length > 0;
 
   return (
     <>
@@ -210,12 +440,17 @@ export function RecentActivitySidebar({ onStateSelect, onBillSelect }) {
         boxShadow: "var(--shadow-elevation-low)",
         border: `1px solid ${colors.border.light}`,
         overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
       }}>
         {/* Header */}
         <div style={{
           padding: `${spacing.md} ${spacing.lg}`,
           borderBottom: `1px solid ${colors.border.light}`,
           backgroundColor: colors.background.secondary,
+          flexShrink: 0,
         }}>
         <h3 style={{
           margin: 0,
@@ -260,10 +495,74 @@ export function RecentActivitySidebar({ onStateSelect, onBillSelect }) {
               </button>
             ))}
           </div>
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+            marginTop: spacing.sm,
+            flexWrap: "wrap",
+          }}>
+              <span style={{
+                fontSize: "10px",
+                fontWeight: typography.fontWeight.semibold,
+                fontFamily: typography.fontFamily.body,
+                color: colors.text.tertiary,
+                textTransform: "uppercase",
+                letterSpacing: "0.4px",
+                marginRight: "2px",
+              }}>
+                Filter
+              </span>
+              <MultiSelectPopover
+                label="States"
+                options={uniqueStates}
+                values={filterStates}
+                onChange={setFilterStates}
+                searchable
+              />
+              <MultiSelectPopover
+                label="Stages"
+                options={uniqueStages}
+                values={filterStages}
+                onChange={setFilterStages}
+              />
+              {filtersActive && (
+                <button
+                  type="button"
+                  onClick={() => { setFilterStates([]); setFilterStages([]); }}
+                  style={{
+                    marginLeft: "auto",
+                    padding: "4px 8px",
+                    border: "none",
+                    background: "transparent",
+                    color: colors.text.tertiary,
+                    fontSize: "11px",
+                    fontFamily: typography.fontFamily.body,
+                    fontWeight: typography.fontWeight.medium,
+                    cursor: "pointer",
+                    textDecoration: "underline",
+                    textUnderlineOffset: "2px",
+                  }}
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
         </div>
 
         {/* List */}
-        <div style={{ maxHeight: "600px", overflowY: "auto" }}>
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+          {displayBills.length === 0 && (
+            <div style={{
+              padding: spacing.lg,
+              textAlign: "center",
+              color: colors.text.tertiary,
+              fontSize: typography.fontSize.sm,
+              fontFamily: typography.fontFamily.body,
+            }}>
+              {filtersActive ? "No bills match the selected filters." : "No bills to show."}
+            </div>
+          )}
           {displayBills.map((bill, i) => {
             const normKey = `${bill.state}:${bill.bill_number.replace(/\s+/g, "").replace(/^([A-Z]+)0+(\d)/, "$1$2").toUpperCase()}`;
             const match = billToResearchId[normKey];

--- a/src/index.css
+++ b/src/index.css
@@ -250,10 +250,6 @@ input:focus-visible {
   -webkit-backdrop-filter: blur(12px);
 }
 
-.app-recent-activity-mobile {
-  display: none;
-}
-
 /* Responsive adjustments */
 @media (max-width: 1024px) {
   .animate-fade-in-up {
@@ -337,17 +333,8 @@ input:focus-visible {
     align-self: stretch !important;
   }
 
-  .app-sidebar-sticky {
-    position: static !important;
-    top: auto !important;
-  }
-
-  .app-recent-activity-desktop {
-    display: none !important;
-  }
-
-  .app-recent-activity-mobile {
-    display: block !important;
+  .app-activity-cell {
+    height: auto !important;
   }
 
   .app-footer-links {


### PR DESCRIPTION
## Summary

### Layout — map & Recent Legislative Activity align at the bottom
- The home grid is now a single row with the map card on the left and the activity card on the right; quick links move to a full-width section below. Previously the activity was sticky in a column alongside map + quick links, so the two cards could never share a bottom edge.
- A `ResizeObserver` on the map card measures `offsetHeight` and the activity cell is clamped to that height. The bill list inside uses `flex: 1 + overflow-y: auto`, so the list scrolls inside the card while the cards share a bottom border.
- On `<=1024px` the height cap is cleared via CSS so the activity stacks naturally below the map.
- Removed duplicated desktop/mobile activity instances (and the unused `.app-recent-activity-*`, `.app-sidebar-sticky` CSS rules).

### Filters on both Analyzed and All Bills
- New `MultiSelectPopover` — portal-rendered dropdown with a checkbox list, optional search, and a "Clear selection" footer. Portal avoids the card's `overflow: hidden` clipping.
- Trigger button tints teal when active; label summarizes the selection (`All states`, `CA`, or `3 states`).
- **States** filter is searchable (50+ options). **Stages** is a plain list.
- Filters apply to both tabs via a shared `matchesFilters` predicate; selections persist across tab switches.
- Null/empty `state` values are filtered out of the options so there's no blank entry at the top.
- `Clear all` link appears when any filter is applied.

## Test plan

- [ ] Home page: bottom edges of the map card and the activity card align on desktop.
- [ ] Resize the window — activity height recomputes.
- [ ] Below 1024px width the layout stacks and activity grows to fit its content.
- [ ] Open States popover, check a few; button shows "N states" and the list filters.
- [ ] Same for Stages. Filters persist when switching between Analyzed / All Bills.
- [ ] Empty-filter result shows "No bills match the selected filters." inside the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)