### PR TITLE
Bump Modal image to Node 22 for supabase-js native WebSocket

### DIFF
--- a/modal_app.py
+++ b/modal_app.py
@@ -31,8 +31,8 @@ image = (
     modal.Image.debian_slim(python_version="3.11")
     .apt_install("curl", "ca-certificates", "git")
     .run_commands(
-        # Install Node.js 20
-        "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
+        # Install Node.js 22 — @supabase/supabase-js needs native WebSocket
+        "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -",
         "apt-get install -y nodejs",
     )
     .run_commands(


### PR DESCRIPTION
The v38 deploy failed in the prerender layer: newer
@supabase/supabase-js requires native WebSocket, which needs
Node >= 22, but the image installed Node 20.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
