### PR TITLE
Paginate home lists, simplify key facts and bill overview

### DIFF
--- a/src/components/RedesignHome.jsx
+++ b/src/components/RedesignHome.jsx
@@ -303,20 +303,18 @@ export default function RedesignHome() {
 
 
   const docket = useMemo(() => {
-    const filtered = rawBills
+    return rawBills
       .filter((b) => (jurisdictionFilter === "federal" ? b.state === "US" : jurisdictionFilter === "state" ? b.state !== "US" : true))
       .filter((b) => !selectedState || b.state === selectedState)
       .filter((b) => inSessionYears(sessionYears, b.last_action_date, b.introduced_date));
-    return { rows: filtered.slice(0, 30), total: filtered.length };
   }, [rawBills, jurisdictionFilter, selectedState, sessionYears]);
 
   const enacted = useMemo(() => {
-    const filtered = rawBills
+    return rawBills
       .filter((b) => b.status === "Signed into Law")
       .filter((b) => (jurisdictionFilter === "federal" ? b.state === "US" : jurisdictionFilter === "state" ? b.state !== "US" : true))
       .filter((b) => !selectedState || b.state === selectedState)
       .filter((b) => inSessionYears(sessionYears, b.last_action_date, b.introduced_date));
-    return { rows: filtered.slice(0, 8), total: filtered.length };
   }, [rawBills, jurisdictionFilter, selectedState, sessionYears]);
 
   const momentum = useMemo(() => {
@@ -328,8 +326,7 @@ export default function RedesignHome() {
       .filter((b) => (isCurrent ? new Date(b.last_action_date).getTime() >= WEEK_CUTOFF_TS : true))
       .filter((b) => (jurisdictionFilter === "federal" ? b.state === "US" : jurisdictionFilter === "state" ? b.state !== "US" : true))
       .filter((b) => !selectedState || b.state === selectedState)
-      .filter((b) => inSessionYears(sessionYears, b.last_action_date, b.introduced_date))
-      .slice(0, 10);
+      .filter((b) => inSessionYears(sessionYears, b.last_action_date, b.introduced_date));
   }, [rawBills, jurisdictionFilter, selectedState, effectiveSessionScope, sessionYears]);
 
   return (
@@ -371,8 +368,7 @@ export default function RedesignHome() {
             normalizeBillNum={normalizeBillNum}
           />
           <EnactedCard
-            bills={enacted.rows}
-            total={enacted.total}
+            bills={enacted}
             onBillClick={handleTrackerRowClick}
             billToResearchId={billToResearchId}
             normalizeBillNum={normalizeBillNum}
@@ -976,51 +972,82 @@ function ImpactIndexCard({ bills }) {
               ))}
             </div>
           </div>
-          {totalPages > 1 && (
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                padding: `${spacing.sm} ${spacing.lg}`,
-                borderTop: `1px solid ${colors.border.light}`,
-                backgroundColor: colors.gray[50],
-              }}
-            >
-              <span
-                style={{
-                  fontSize: typography.fontSize.xs,
-                  color: colors.text.tertiary,
-                  fontFamily: typography.fontFamily.body,
-                  fontVariantNumeric: "tabular-nums",
-                }}
-              >
-                {start + 1}–{start + pageRows.length} of {bills.length}
-              </span>
-              <div style={{ display: "flex", alignItems: "center", gap: spacing.sm }}>
-                <PagerButton disabled={safePage === 0} onClick={() => setPage(safePage - 1)}>
-                  ‹ Prev
-                </PagerButton>
-                <span
-                  style={{
-                    fontSize: typography.fontSize.xs,
-                    color: colors.text.secondary,
-                    fontFamily: typography.fontFamily.body,
-                    fontVariantNumeric: "tabular-nums",
-                  }}
-                >
-                  {safePage + 1} / {totalPages}
-                </span>
-                <PagerButton disabled={safePage >= totalPages - 1} onClick={() => setPage(safePage + 1)}>
-                  Next ›
-                </PagerButton>
-              </div>
-            </div>
-          )}
+          <PagerFooter
+            page={safePage}
+            totalPages={totalPages}
+            start={start}
+            pageCount={pageRows.length}
+            total={bills.length}
+            setPage={setPage}
+          />
         </>
       )}
     </Card>
   );
+}
+
+function PagerFooter({ page, totalPages, start, pageCount, total, setPage }) {
+  if (totalPages <= 1) return null;
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: `${spacing.sm} ${spacing.lg}`,
+        borderTop: `1px solid ${colors.border.light}`,
+        backgroundColor: colors.gray[50],
+      }}
+    >
+      <span
+        style={{
+          fontSize: typography.fontSize.xs,
+          color: colors.text.tertiary,
+          fontFamily: typography.fontFamily.body,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {start + 1}–{start + pageCount} of {total}
+      </span>
+      <div style={{ display: "flex", alignItems: "center", gap: spacing.sm }}>
+        <PagerButton disabled={page === 0} onClick={() => setPage(page - 1)}>
+          ‹ Prev
+        </PagerButton>
+        <span
+          style={{
+            fontSize: typography.fontSize.xs,
+            color: colors.text.secondary,
+            fontFamily: typography.fontFamily.body,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {page + 1} / {totalPages}
+        </span>
+        <PagerButton disabled={page >= totalPages - 1} onClick={() => setPage(page + 1)}>
+          Next ›
+        </PagerButton>
+      </div>
+    </div>
+  );
+}
+
+// Shared pagination state for the three home-page list cards (10 rows/page).
+const LIST_PAGE_SIZE = 10;
+
+function usePagedRows(rows) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(rows.length / LIST_PAGE_SIZE));
+  // Clamp instead of resetting via effect so filter changes can't strand us
+  // on a page that no longer exists.
+  const safePage = Math.min(page, totalPages - 1);
+  const start = safePage * LIST_PAGE_SIZE;
+  return {
+    pageRows: rows.slice(start, start + LIST_PAGE_SIZE),
+    page: safePage,
+    totalPages,
+    start,
+    setPage,
+  };
 }
 
 function PagerButton({ disabled, onClick, children }) {
@@ -1261,10 +1288,8 @@ function ImpactRow({ rank, bill, last }) {
 // ============== Docket ==============
 
 function DocketCard({ docket, loading, onBillClick, billToResearchId, normalizeBillNum }) {
-  const { rows, total } = docket;
-  const subtitle = total > rows.length
-    ? `${rows.length} of ${total} bills`
-    : `${total} bill${total === 1 ? "" : "s"}`;
+  const { pageRows: rows, page, totalPages, start, setPage } = usePagedRows(docket);
+  const subtitle = `${docket.length} bill${docket.length === 1 ? "" : "s"}`;
   return (
     <Card>
       <CardHeader eyebrow="All tracked" title="On the Docket" subtitle={subtitle} />
@@ -1305,6 +1330,14 @@ function DocketCard({ docket, loading, onBillClick, billToResearchId, normalizeB
           />
         ))}
       </div>
+      <PagerFooter
+        page={page}
+        totalPages={totalPages}
+        start={start}
+        pageCount={rows.length}
+        total={docket.length}
+        setPage={setPage}
+      />
     </Card>
   );
 }
@@ -1411,10 +1444,9 @@ function DocketRow({ bill, last, onClick, isScored }) {
 
 // ============== Enacted (Signed into Law) ==============
 
-function EnactedCard({ bills, total, onBillClick, billToResearchId, normalizeBillNum }) {
-  const subtitle = total > bills.length
-    ? `${bills.length} of ${total} bills`
-    : `${total} bill${total === 1 ? "" : "s"}`;
+function EnactedCard({ bills, onBillClick, billToResearchId, normalizeBillNum }) {
+  const { pageRows, page, totalPages, start, setPage } = usePagedRows(bills);
+  const subtitle = `${bills.length} bill${bills.length === 1 ? "" : "s"}`;
   return (
     <Card>
       <CardHeader eyebrow="Signed into law" title="Enacted" subtitle={subtitle} />
@@ -1432,17 +1464,25 @@ function EnactedCard({ bills, total, onBillClick, billToResearchId, normalizeBil
             Nothing enacted yet.
           </div>
         ) : (
-          bills.map((b, i) => (
+          pageRows.map((b, i) => (
             <EnactedRow
               key={`enacted-${b.state}-${b.bill_number}-${i}`}
               bill={b}
-              last={i === bills.length - 1}
+              last={i === pageRows.length - 1}
               onClick={() => onBillClick(b)}
               isScored={!!billToResearchId[`${b.state}:${normalizeBillNum(b.bill_number)}`]}
             />
           ))
         )}
       </div>
+      <PagerFooter
+        page={page}
+        totalPages={totalPages}
+        start={start}
+        pageCount={pageRows.length}
+        total={bills.length}
+        setPage={setPage}
+      />
     </Card>
   );
 }
@@ -1517,6 +1557,7 @@ function EnactedRow({ bill, last, onClick, isScored }) {
 // ============== Momentum ==============
 
 function MomentumCard({ momentum, isCurrentScope, onBillClick, billToResearchId, normalizeBillNum }) {
+  const { pageRows, page, totalPages, start, setPage } = usePagedRows(momentum);
   return (
     <Card>
       <CardHeader
@@ -1538,17 +1579,25 @@ function MomentumCard({ momentum, isCurrentScope, onBillClick, billToResearchId,
             {isCurrentScope ? "Quiet week." : "No recorded actions."}
           </div>
         ) : (
-          momentum.map((b, i) => (
+          pageRows.map((b, i) => (
             <MomentumRow
               key={`m-${b.state}-${b.bill_number}-${i}`}
               bill={b}
-              last={i === momentum.length - 1}
+              last={i === pageRows.length - 1}
               onClick={() => onBillClick(b)}
               isScored={!!billToResearchId[`${b.state}:${normalizeBillNum(b.bill_number)}`]}
             />
           ))
         )}
       </div>
+      <PagerFooter
+        page={page}
+        totalPages={totalPages}
+        start={start}
+        pageCount={pageRows.length}
+        total={momentum.length}
+        setPage={setPage}
+      />
     </Card>
   );
 }
@@ -1685,7 +1734,7 @@ function RequestCta() {
             lineHeight: 1.45,
           }}
         >
-          Point us at a bill and we'll run distributional impact, poverty reach, and district-level cuts — usually within a week.
+          Point us at a bill and we&apos;ll run distributional impact, poverty reach, and district-level cuts — usually within a week.
         </p>
       </div>
       <a

--- a/src/components/reform/BillOverview.jsx
+++ b/src/components/reform/BillOverview.jsx
@@ -230,21 +230,10 @@ export default function BillOverview({ bill, impact, reformId }) {
             alignItems: "flex-start",
             justifyContent: "space-between",
             gap: spacing.lg,
-            marginBottom: spacing.lg,
+            marginBottom: bill?.status || bill?.url ? spacing.md : 0,
           }}>
-            <div>
-              <h4 style={{
-                margin: 0,
-                fontSize: typography.fontSize.xl,
-                fontWeight: typography.fontWeight.bold,
-                fontFamily: typography.fontFamily.primary,
-                color: colors.secondary[900],
-              }}>
-                {bill?.title || bill?.bill || bill?.id?.toUpperCase()}
-              </h4>
-              <div style={{ display: "flex", alignItems: "center", gap: spacing.sm, marginTop: spacing.sm, flexWrap: "wrap" }}>
-                {bill?.status && <StatusBadge status={bill.status} />}
-              </div>
+            <div style={{ display: "flex", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
+              {bill?.status && <StatusBadge status={bill.status} />}
             </div>
 
             {bill?.url && (

--- a/src/components/reform/KeyFacts.jsx
+++ b/src/components/reform/KeyFacts.jsx
@@ -102,64 +102,6 @@ function generateKeyFacts(data, year) {
   return facts;
 }
 
-const ICON_PATHS = {
-  revenue: (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-    />
-  ),
-  winners: (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
-    />
-  ),
-  losers: (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M13 17h8m0 0V9m0 8l-8-8-4 4-6-6"
-    />
-  ),
-  poverty: (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-    />
-  ),
-  childPoverty: (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
-    />
-  ),
-  custom: (
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-    />
-  ),
-};
-
-const FactIcon = ({ type }) => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-  >
-    {ICON_PATHS[type] || ICON_PATHS.custom}
-  </svg>
-);
-
 export default function KeyFacts({ impact, reformId }) {
   const availableYears = impact?.impactsByYear
     ? Object.keys(impact.impactsByYear).sort()
@@ -189,17 +131,17 @@ export default function KeyFacts({ impact, reformId }) {
   return (
     <div
       style={{
-        backgroundColor: colors.primary[50],
+        backgroundColor: colors.white,
         borderRadius: spacing.radius.xl,
-        border: `1px solid ${colors.primary[200]}`,
+        border: `1px solid ${colors.border.light}`,
         overflow: "hidden",
       }}
     >
       <div
         style={{
           padding: `${spacing.md} ${spacing.xl}`,
-          borderBottom: `1px solid ${colors.primary[200]}`,
-          backgroundColor: colors.primary[100],
+          borderBottom: `1px solid ${colors.border.light}`,
+          backgroundColor: colors.background.secondary,
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
@@ -213,7 +155,7 @@ export default function KeyFacts({ impact, reformId }) {
             fontFamily: typography.fontFamily.body,
             textTransform: "uppercase",
             letterSpacing: "0.5px",
-            color: colors.primary[800],
+            color: colors.text.tertiary,
           }}
         >
           Key Facts
@@ -259,28 +201,12 @@ export default function KeyFacts({ impact, reformId }) {
               style={{
                 display: "flex",
                 alignItems: "center",
-                gap: spacing.md,
                 padding: `${spacing.md} ${spacing.lg}`,
-                backgroundColor: colors.white,
+                backgroundColor: colors.background.secondary,
                 borderRadius: spacing.radius.lg,
-                border: `1px solid ${colors.primary[100]}`,
+                border: `1px solid ${colors.border.light}`,
               }}
             >
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 32,
-                  height: 32,
-                  borderRadius: spacing.radius.md,
-                  backgroundColor: colors.primary[100],
-                  color: colors.primary[700],
-                  flexShrink: 0,
-                }}
-              >
-                <FactIcon type={fact.icon} />
-              </div>
               <span
                 style={{
                   fontSize: typography.fontSize.sm,


### PR DESCRIPTION
## Summary
Follow-up to #174: ports the last pieces of the pre-migration redesign iteration onto the Next.js codebase.

## Changes
- **Paginated list cards**: On the Docket / Moving this Week / Enacted now paginate at 10 rows/page instead of silently truncating at 30/10/8; the pager footer is extracted from the scored-bills table into a shared `PagerFooter` component with a `usePagedRows` hook (page clamped, not reset, so filter changes can't strand you on a missing page)
- **KeyFacts**: drop the icon column and restyle from primary-tinted surfaces to neutral white/gray
- **BillOverview**: remove the duplicate bill title heading (the page header already shows it); keep the status badge and source link
- Fix a pre-existing unescaped-apostrophe lint error in `RequestCta`

## Testing
- `bun run lint` — 0 errors
- `bun run test` — 31/31 pass (Node 22)
- `bun run build` — Next.js static export succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>