### PR TITLE
Sort bills with no action date last instead of first

### DIFF
--- a/src/components/BillActivityFeed.jsx
+++ b/src/components/BillActivityFeed.jsx
@@ -334,7 +334,7 @@ export function useProcessedBills(stateFilter) {
         .select("state, bill_number, title, status, last_action, last_action_date, confidence_score, reform_type, legiscan_url")
         .gt("confidence_score", 19)
         .is("skipped_reason", null)
-        .order("last_action_date", { ascending: false });
+        .order("last_action_date", { ascending: false, nullsFirst: false });
 
       if (stateFilter) {
         query = query.eq("state", stateFilter);


### PR DESCRIPTION
## Summary
Bills with no `last_action_date` were appearing at the top of the On the Docket card because Postgres sorts NULLs first on a descending order. Adding `nullsFirst: false` to the `useProcessedBills` query puts undated bills last for every consumer (docket, state panel, activity sidebar).

## Testing
- `bun run lint` — 0 errors
- `bun run test` — 31/31 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>