### PR TITLE
Score HR 1425 (Child Tax Credit to $5,000, fully refundable)

### DIFF
--- a/analyses/us-hr1425.json
+++ b/analyses/us-hr1425.json
@@ -1,0 +1,179 @@
+{
+  "research": {
+    "id": "us-hr1425",
+    "state": "US",
+    "type": "bill",
+    "status": "in_review",
+    "title": "HR 1425: Child Tax Credit to $5,000, fully refundable",
+    "url": "https://www.congress.gov/bill/119th-congress/house-bill/1425",
+    "date": "2026-07-06",
+    "author": "Rep. Mackenzie, Ryan [R-PA-7]",
+    "description": "HR 1425 amends IRC \u00a724 to raise the Child Tax Credit to $5,000 per qualifying child (from the current-law $2,200 base), make it fully refundable, and remove the income phase-out. PolicyEngine models it by setting the base CTC amount to $5,000, enabling full refundability, and zeroing the phase-out from tax year 2025, against current law including OBBBA.",
+    "key_findings": [
+      "Reduces federal revenue by $207 billion in 2026 (PolicyEngine, Enhanced CPS 2024, policyengine-us 1.729.3)",
+      "Cuts child poverty (SPM) by 47%, from 17.2% to 9.1%",
+      "Cuts overall poverty by 19%, from 16.1% to 13.1%",
+      "39.6% of households gain; none lose"
+    ],
+    "tags": [
+      "federal",
+      "child-tax-credit",
+      "income-tax",
+      "poverty"
+    ]
+  },
+  "reform_impacts": {
+    "id": "us-hr1425",
+    "computed": true,
+    "computed_at": "2026-07-06T21:54:21.235952+00:00",
+    "budgetary_impact": {
+      "stateRevenueImpact": -207128753792.6172,
+      "netCost": -207128753792.6172,
+      "households": 163970336
+    },
+    "poverty_impact": {
+      "baselineRate": 0.16144204475368448,
+      "reformRate": 0.13107471721599867,
+      "change": -0.030367327537685812,
+      "percentChange": -18.810048884116824
+    },
+    "child_poverty_impact": {
+      "baselineRate": 0.17189349110062482,
+      "reformRate": 0.09063162003300755,
+      "change": -0.08126187106761727,
+      "percentChange": -47.27454806304873
+    },
+    "winners_losers": {
+      "gainMore5Pct": 0.2011922204495172,
+      "gainLess5Pct": 0.19502957274762278,
+      "noChange": 0.60377820680286,
+      "loseLess5Pct": 0.0,
+      "loseMore5Pct": 0.0,
+      "intraDecile": {
+        "all": {
+          "gainMore5Pct": 0.2011922204495172,
+          "gainLess5Pct": 0.19502957274762278,
+          "noChange": 0.60377820680286,
+          "loseLess5Pct": 0.0,
+          "loseMore5Pct": 0.0
+        },
+        "deciles": {
+          "1": {
+            "gainMore5Pct": 0.15846739006459598,
+            "gainLess5Pct": 0.0,
+            "noChange": 0.841532609935404,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "2": {
+            "gainMore5Pct": 0.3112490796432626,
+            "gainLess5Pct": 0.0,
+            "noChange": 0.6887509203567374,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "3": {
+            "gainMore5Pct": 0.361752958565844,
+            "gainLess5Pct": 0.0,
+            "noChange": 0.638247041434156,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "4": {
+            "gainMore5Pct": 0.4473284168173885,
+            "gainLess5Pct": 0.04573681032378519,
+            "noChange": 0.5069347728588263,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "5": {
+            "gainMore5Pct": 0.27398772522262677,
+            "gainLess5Pct": 0.1014651493685397,
+            "noChange": 0.6245471254088335,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "6": {
+            "gainMore5Pct": 0.21099926922624765,
+            "gainLess5Pct": 0.19637071818705207,
+            "noChange": 0.5926300125867002,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "7": {
+            "gainMore5Pct": 0.10459145995506096,
+            "gainLess5Pct": 0.3762565046691679,
+            "noChange": 0.5191520353757711,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "8": {
+            "gainMore5Pct": 0.10114311705484978,
+            "gainLess5Pct": 0.38128277539924443,
+            "noChange": 0.5175741075459057,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "9": {
+            "gainMore5Pct": 0.040626209600936325,
+            "gainLess5Pct": 0.3212435499443583,
+            "noChange": 0.6381302404547053,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          },
+          "10": {
+            "gainMore5Pct": 0.001776578344359676,
+            "gainLess5Pct": 0.5279402195840804,
+            "noChange": 0.47028320207155994,
+            "loseLess5Pct": 0.0,
+            "loseMore5Pct": 0.0
+          }
+        }
+      }
+    },
+    "decile_impact": {
+      "relative": {
+        "1": 0.027867120069701466,
+        "2": 0.025407300995088155,
+        "3": 0.02985730014291749,
+        "4": 0.030423716888181872,
+        "5": 0.017969270903449013,
+        "6": 0.013753951260767743,
+        "7": 0.01164752742474685,
+        "8": 0.01031173110468671,
+        "9": 0.0067998081301505735,
+        "10": 0.001956191040771728
+      },
+      "average": {
+        "1": 434.27917042880716,
+        "2": 842.397473205693,
+        "3": 1350.1467012859127,
+        "4": 1801.3668126118112,
+        "5": 1335.1370736756503,
+        "6": 1311.3527676743681,
+        "7": 1442.2585282617301,
+        "8": 1553.944211764154,
+        "9": 1386.9579571120103,
+        "10": 2198.853672944784
+      }
+    },
+    "district_impacts": null,
+    "reform_params": {
+      "gov.irs.credits.ctc.amount.base[0].amount": {
+        "2025-01-01.2100-12-31": 5000
+      },
+      "gov.irs.credits.ctc.refundable.fully_refundable": {
+        "2025-01-01.2100-12-31": true
+      },
+      "gov.irs.credits.ctc.phase_out.amount": {
+        "2025-01-01.2100-12-31": 0
+      }
+    },
+    "model_notes": {
+      "analysis_year": 2026
+    },
+    "policyengine_us_version": "1.729.3",
+    "dataset_name": "policyengine-us-data",
+    "dataset_version": "1.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
Second federal analysis, reusing the scoring path built for HR 904. HR 1425 (Mackenzie, R-PA-7) amends IRC §24 to raise the Child Tax Credit to **$5,000 per qualifying child**, make it **fully refundable**, and **remove the income phase-out** (effective TY2025).

## Results (2026, national Enhanced CPS, policyengine-us 1.729.3)
| Metric | Value |
|---|---|
| Federal revenue | **−$207B** |
| Child poverty (SPM) | **17.2% → 9.1% (−47%)** |
| Overall poverty (SPM) | 16.1% → 13.1% (−19%) |
| Households gaining | 39.6% (0 losing) |

The ~47% child-poverty reduction is consistent with the evidence base on the 2021 ARPA CTC expansion (a smaller $3,000/$3,600 fully-refundable credit); the larger $5,000 amount with no phase-out lands modestly higher. Top-decile gains ($2,199 avg) reflect the removal of the income limit, exactly as the bill intends.

## Modeling
Three parameter changes against current law (which already includes OBBBA):
- `gov.irs.credits.ctc.amount.base[0].amount` → 5000 (per-qualifying-child §24(a) amount; under-17 bracket)
- `gov.irs.credits.ctc.refundable.fully_refundable` → true
- `gov.irs.credits.ctc.phase_out.amount` → 0 (removes §24(b) income limitation)

Verified in the model source that `fully_refundable=true` returns the full per-child maximum uncapped (not the $1,700 `individual_max`), so the $5,000 is genuinely fully refundable.

## Publish sequence (after merge)
Same as HR 904: publish-bill fires and fails once (row doesn't exist yet) → run publish-analysis with `analyses/us-hr1425.json` → re-run publish-bill to flip to `published`.

## Testing
Microsim ran clean end-to-end; artifact validated with `publish_analysis.py --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>