### PR TITLE
Fix federal refresh upsert conflict; add standalone triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,41 @@
+name: Triage Unscored Bills
+
+# On-demand modelability scoring for unscored bills (confidence_score=0),
+# state or federal. The daily pipeline also runs this on day 3, but this lets
+# it run standalone — e.g. after a discovery run that inserted new bills but
+# whose triage step was skipped.
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Max bills to score (blank = all unscored)"
+        required: false
+        type: string
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install supabase anthropic
+
+      - name: Triage unscored bills
+        run: |
+          if [ -n "${{ inputs.limit }}" ]; then
+            python scripts/auto_triage.py --limit ${{ inputs.limit }}
+          else
+            python scripts/auto_triage.py
+          fi

--- a/scripts/congress_monitor.py
+++ b/scripts/congress_monitor.py
@@ -437,7 +437,7 @@ def main():
             row = build_row(seed, bill)
             print(f"{row['status']} | {row['last_action'][:60]} ({row['last_action_date']})")
             if not args.dry_run:
-                supabase.table("processed_bills").upsert(row).execute()
+                supabase.table("processed_bills").upsert(row, on_conflict="bill_id").execute()
             updated += 1
         except Exception as e:
             print(f"error: {e}")
@@ -491,7 +491,7 @@ def discover_and_insert(supabase, api_key, args):
             row = build_discovered_row(congress, bill_type, number, bill)
             print(f"  + US {label}: {row['title'][:60]} [{row['status']}]")
             if not args.dry_run:
-                supabase.table("processed_bills").upsert(row).execute()
+                supabase.table("processed_bills").upsert(row, on_conflict="bill_id").execute()
             inserted += 1
         except Exception as e:
             print(f"  ! US {label}: {e}")


### PR DESCRIPTION
The congress_monitor refresh loop re-upserts the curated seeds every run, but the upsert didn't set `on_conflict`, so PostgREST resolved on the primary key (`id`) not `bill_id` — inserting a row that violated the `bill_id` unique constraint. It only worked on first insert; every refresh since failed with `duplicate key ... bill_id_key`, returned exit 1, and skipped the day-3 triage step (which is why 52 discovered bills are sitting untriaged at score 0).

- `on_conflict="bill_id"` on both upserts so refresh updates instead of colliding.
- `triage.yml` (workflow_dispatch) to run auto_triage standalone — scores the stranded bills without re-running the 40-min pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>