### PR TITLE
Re-publish HR 904 and HR 1425 on populace-us

### DIFF
--- a/analyses/us-hr1425.json
+++ b/analyses/us-hr1425.json
@@ -10,12 +10,12 @@
     "author": "Rep. Mackenzie, Ryan [R-PA-7]",
     "description": "HR 1425 amends IRC \u00a724 to raise the Child Tax Credit to $5,000 per qualifying child (from the current-law $2,200 base), make it fully refundable, and remove the income phase-out. PolicyEngine models it by setting the base CTC amount to $5,000, enabling full refundability, and zeroing the phase-out from tax year 2025, against current law including OBBBA.",
     "key_findings": [
-      "Reduces federal revenue by $207 billion in 2026 (PolicyEngine, Enhanced CPS 2024, policyengine-us 1.729.3)",
-      "Cuts child poverty (SPM) by 47%, from 17.2% to 9.1%",
-      "Cuts overall poverty by 19%, from 16.1% to 13.1%",
-      "39.6% of households gain; none lose",
-      "External check (cost): consistent with PolicyEngine's near-identical $5,000 fully-refundable CTC analysis ($241B, 2025) and CRFB's $2-3T/10yr band for this reform shape; the lower figure reflects the higher OBBBA $2,200 baseline.",
-      "External check (child poverty): ARPA's 2021 expansion cut child poverty ~46% (Census SPM) for a smaller credit; PolicyEngine's comparable $5,000 analysis found 41%. Our 47% is defensible but on the optimistic edge of the evidence range."
+      "Reduces federal revenue by $225.5 billion in 2026 (PolicyEngine, populace-us 2024, policyengine-us 1.729.3)",
+      "Cuts child poverty (SPM) by 40%, from 16.6% to 9.9%",
+      "Cuts overall poverty by 14%, from 16.9% to 14.5%",
+      "43.5% of households gain; none lose",
+      "External check (cost): within CRFB's $2-3T/10yr band for a $5,000 fully-refundable no-phase-out CTC, and consistent with PolicyEngine's near-identical $5,000 CTC analysis ($241B).",
+      "External check (child poverty): the 40% cut closely matches PolicyEngine's comparable $5,000 CTC analysis (41%) and ARPA's measured 46% (Census SPM) for a smaller credit."
     ],
     "tags": [
       "federal",
@@ -27,106 +27,106 @@
   "reform_impacts": {
     "id": "us-hr1425",
     "computed": true,
-    "computed_at": "2026-07-06T21:54:21.235952+00:00",
+    "computed_at": "2026-07-09T14:09:18.690455+00:00",
     "budgetary_impact": {
-      "stateRevenueImpact": -207128753792.6172,
-      "netCost": -207128753792.6172,
-      "households": 163970336
+      "stateRevenueImpact": -225517387052.77197,
+      "netCost": -225517387052.77197,
+      "households": 162801264
     },
     "poverty_impact": {
-      "baselineRate": 0.16144204475368448,
-      "reformRate": 0.13107471721599867,
-      "change": -0.030367327537685812,
-      "percentChange": -18.810048884116824
+      "baselineRate": 0.16934958537376332,
+      "reformRate": 0.14514657558432897,
+      "change": -0.02420300978943435,
+      "percentChange": -14.291744344113422
     },
     "child_poverty_impact": {
-      "baselineRate": 0.17189349110062482,
-      "reformRate": 0.09063162003300755,
-      "change": -0.08126187106761727,
-      "percentChange": -47.27454806304873
+      "baselineRate": 0.16552530351554517,
+      "reformRate": 0.0994270700046663,
+      "change": -0.06609823351087887,
+      "percentChange": -39.932404355731215
     },
     "winners_losers": {
-      "gainMore5Pct": 0.2011922204495172,
-      "gainLess5Pct": 0.19502957274762278,
-      "noChange": 0.60377820680286,
+      "gainMore5Pct": 0.2359429660313952,
+      "gainLess5Pct": 0.19941092306249536,
+      "noChange": 0.5646461109061095,
       "loseLess5Pct": 0.0,
       "loseMore5Pct": 0.0,
       "intraDecile": {
         "all": {
-          "gainMore5Pct": 0.2011922204495172,
-          "gainLess5Pct": 0.19502957274762278,
-          "noChange": 0.60377820680286,
+          "gainMore5Pct": 0.2359429660313952,
+          "gainLess5Pct": 0.19941092306249536,
+          "noChange": 0.5646461109061095,
           "loseLess5Pct": 0.0,
           "loseMore5Pct": 0.0
         },
         "deciles": {
           "1": {
-            "gainMore5Pct": 0.15846739006459598,
-            "gainLess5Pct": 0.0,
-            "noChange": 0.841532609935404,
+            "gainMore5Pct": 0.07569045492490507,
+            "gainLess5Pct": 0.00015878455530685606,
+            "noChange": 0.9241507605197881,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "2": {
-            "gainMore5Pct": 0.3112490796432626,
+            "gainMore5Pct": 0.2040987518001576,
             "gainLess5Pct": 0.0,
-            "noChange": 0.6887509203567374,
+            "noChange": 0.7959012481998424,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "3": {
-            "gainMore5Pct": 0.361752958565844,
+            "gainMore5Pct": 0.401646097738456,
             "gainLess5Pct": 0.0,
-            "noChange": 0.638247041434156,
+            "noChange": 0.598353902261544,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "4": {
-            "gainMore5Pct": 0.4473284168173885,
-            "gainLess5Pct": 0.04573681032378519,
-            "noChange": 0.5069347728588263,
+            "gainMore5Pct": 0.4295826479126756,
+            "gainLess5Pct": 0.07226120170229562,
+            "noChange": 0.4981561503850288,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "5": {
-            "gainMore5Pct": 0.27398772522262677,
-            "gainLess5Pct": 0.1014651493685397,
-            "noChange": 0.6245471254088335,
+            "gainMore5Pct": 0.3150785243835341,
+            "gainLess5Pct": 0.19522684176729604,
+            "noChange": 0.4896946338491699,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "6": {
-            "gainMore5Pct": 0.21099926922624765,
-            "gainLess5Pct": 0.19637071818705207,
-            "noChange": 0.5926300125867002,
+            "gainMore5Pct": 0.31018975798758547,
+            "gainLess5Pct": 0.2595294954984242,
+            "noChange": 0.43028074651399034,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "7": {
-            "gainMore5Pct": 0.10459145995506096,
-            "gainLess5Pct": 0.3762565046691679,
-            "noChange": 0.5191520353757711,
+            "gainMore5Pct": 0.3323836049129661,
+            "gainLess5Pct": 0.1760710001373924,
+            "noChange": 0.4915453949496415,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "8": {
-            "gainMore5Pct": 0.10114311705484978,
-            "gainLess5Pct": 0.38128277539924443,
-            "noChange": 0.5175741075459057,
+            "gainMore5Pct": 0.20056976407984525,
+            "gainLess5Pct": 0.39344368075005454,
+            "noChange": 0.4059865551701002,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "9": {
-            "gainMore5Pct": 0.040626209600936325,
-            "gainLess5Pct": 0.3212435499443583,
-            "noChange": 0.6381302404547053,
+            "gainMore5Pct": 0.08461277182437185,
+            "gainLess5Pct": 0.4481547221560889,
+            "noChange": 0.4672325060195392,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "10": {
-            "gainMore5Pct": 0.001776578344359676,
-            "gainLess5Pct": 0.5279402195840804,
-            "noChange": 0.47028320207155994,
+            "gainMore5Pct": 0.005577284749454878,
+            "gainLess5Pct": 0.4492635040580953,
+            "noChange": 0.5451592111924497,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           }
@@ -135,28 +135,28 @@
     },
     "decile_impact": {
       "relative": {
-        "1": 0.027867120069701466,
-        "2": 0.025407300995088155,
-        "3": 0.02985730014291749,
-        "4": 0.030423716888181872,
-        "5": 0.017969270903449013,
-        "6": 0.013753951260767743,
-        "7": 0.01164752742474685,
-        "8": 0.01031173110468671,
-        "9": 0.0067998081301505735,
-        "10": 0.001956191040771728
+        "1": 0.010841045688743844,
+        "2": 0.01643894830585973,
+        "3": 0.025236992823788086,
+        "4": 0.029241782012056544,
+        "5": 0.02578485571025264,
+        "6": 0.0243966315017607,
+        "7": 0.01889620276166757,
+        "8": 0.01867250228169061,
+        "9": 0.010998866112993824,
+        "10": 0.0036598922704236905
       },
       "average": {
-        "1": 434.27917042880716,
-        "2": 842.397473205693,
-        "3": 1350.1467012859127,
-        "4": 1801.3668126118112,
-        "5": 1335.1370736756503,
-        "6": 1311.3527676743681,
-        "7": 1442.2585282617301,
-        "8": 1553.944211764154,
-        "9": 1386.9579571120103,
-        "10": 2198.853672944784
+        "1": 198.7423155200796,
+        "2": 544.309935740036,
+        "3": 1126.8798371837033,
+        "4": 1667.2946874421984,
+        "5": 1795.996646954168,
+        "6": 2041.5670583764725,
+        "7": 1919.4138366256852,
+        "8": 2386.6356401294393,
+        "9": 1941.641923521937,
+        "10": 1836.485322726397
       }
     },
     "district_impacts": null,
@@ -174,9 +174,9 @@
     "model_notes": {
       "analysis_year": 2026,
       "external_comparison": {
-        "verdict": "corroborated (child-poverty effect at optimistic edge)",
-        "pe_single_year_2026_cost": -207000000000.0,
-        "pe_child_poverty_reduction_pct": 47,
+        "verdict": "corroborated",
+        "pe_single_year_2026_cost": -225500000000.0,
+        "pe_child_poverty_reduction_pct": 40,
         "anchors": [
           {
             "source": "PolicyEngine Vance $5,000 CTC (near-identical reform)",
@@ -207,7 +207,7 @@
       }
     },
     "policyengine_us_version": "1.729.3",
-    "dataset_name": "policyengine-us-data",
+    "dataset_name": "populace-us",
     "dataset_version": "1.17.0"
   }
 }

--- a/analyses/us-hr904.json
+++ b/analyses/us-hr904.json
@@ -10,11 +10,10 @@
     "author": "Rep. Jefferson Van Drew (R-NJ-2)",
     "description": "HR 904 repeals the inclusion of Social Security benefits in gross income under IRC \u00a7 86, ending federal income taxation of Social Security benefits for all recipients. PolicyEngine models the repeal by zeroing both tiers of the taxability formula from tax year 2026, on top of current law including the OBBBA senior deduction.",
     "key_findings": [
-      "Reduces federal revenue by $94.5 billion in 2026 (PolicyEngine, Enhanced CPS 2024, policyengine-us 1.729.3)",
-      "10.4% of households gain; none lose",
-      "Average gains rise with income: $104/household in the third decile to $2,817 in the top decile",
+      "Reduces federal revenue by $97.8 billion in 2026 (PolicyEngine, populace-us 2024, policyengine-us 1.729.3)",
+      "10.2% of households gain; none lose",
       "No measurable change in overall or child poverty (SPM)",
-      "External check: matches PolicyEngine's prior published single-year score ($98.9B for 2025, pre-OBBBA) and CRFB's independent ~$94B first-year estimate; implies ~$1.4-1.6T over 2026-2035, consistent with CRFB, TPC ($1.5T), and Penn Wharton ($1.45T). The slightly lower figure reflects the OBBBA senior deduction shrinking the taxable-benefit base."
+      "External check: matches CRFB's independent ~$94B first-year estimate and PolicyEngine's prior published single-year score ($98.9B, 2025); implies ~$1.4-1.6T over 2026-2035, consistent with CRFB, TPC ($1.5T), and Penn Wharton ($1.45T)."
     ],
     "tags": [
       "federal",
@@ -25,107 +24,107 @@
   "reform_impacts": {
     "id": "us-hr904",
     "computed": true,
-    "computed_at": "2026-07-06T19:21:04.236006+00:00",
+    "computed_at": "2026-07-09T14:02:40.470438+00:00",
     "budgetary_impact": {
-      "stateRevenueImpact": -94524828141.82031,
-      "netCost": -94524828141.82031,
-      "households": 163970336
+      "stateRevenueImpact": -97846943795.19678,
+      "netCost": -97846943795.19678,
+      "households": 162801264
     },
     "poverty_impact": {
-      "baselineRate": 0.16144204475368448,
-      "reformRate": 0.16144989880438798,
-      "change": 7.854050703498539e-06,
-      "percentChange": 0.004864935101312443
+      "baselineRate": 0.16934958537376332,
+      "reformRate": 0.16910406866066247,
+      "change": -0.0002455167131008573,
+      "percentChange": -0.14497627057012819
     },
     "child_poverty_impact": {
-      "baselineRate": 0.17189349110062482,
-      "reformRate": 0.17189349110062482,
-      "change": 0.0,
-      "percentChange": 0.0
+      "baselineRate": 0.16552530351554517,
+      "reformRate": 0.1655239856249619,
+      "change": -1.3178905832744725e-06,
+      "percentChange": -0.0007961867794736917
     },
     "winners_losers": {
-      "gainMore5Pct": 0.017042695825584375,
-      "gainLess5Pct": 0.08725985612196992,
-      "noChange": 0.8956828422380397,
-      "loseLess5Pct": 1.4605814406109125e-05,
+      "gainMore5Pct": 0.01705567030939435,
+      "gainLess5Pct": 0.08510920019052304,
+      "noChange": 0.8978339425387999,
+      "loseLess5Pct": 1.1869612828017118e-06,
       "loseMore5Pct": 0.0,
       "intraDecile": {
         "all": {
-          "gainMore5Pct": 0.017042695825584375,
-          "gainLess5Pct": 0.08725985612196992,
-          "noChange": 0.8956828422380397,
-          "loseLess5Pct": 1.4605814406109125e-05,
+          "gainMore5Pct": 0.01705567030939435,
+          "gainLess5Pct": 0.08510920019052304,
+          "noChange": 0.8978339425387999,
+          "loseLess5Pct": 1.1869612828017118e-06,
           "loseMore5Pct": 0.0
         },
         "deciles": {
           "1": {
-            "gainMore5Pct": 0.0,
-            "gainLess5Pct": 0.0014741178899074661,
-            "noChange": 0.9985258821100925,
+            "gainMore5Pct": 0.001142632057389674,
+            "gainLess5Pct": 0.00017350318326918998,
+            "noChange": 0.9986838647593411,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "2": {
-            "gainMore5Pct": 0.0,
-            "gainLess5Pct": 0.003940329131985918,
-            "noChange": 0.9960596708680141,
+            "gainMore5Pct": 0.00017276011687525464,
+            "gainLess5Pct": 0.01068494839354678,
+            "noChange": 0.989142291489578,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "3": {
-            "gainMore5Pct": 0.006899451218723085,
-            "gainLess5Pct": 0.04421682214783449,
-            "noChange": 0.9488837266334424,
+            "gainMore5Pct": 0.0009980605310648738,
+            "gainLess5Pct": 0.03429994757886071,
+            "noChange": 0.9647019918900744,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "4": {
-            "gainMore5Pct": 0.003130618834739891,
-            "gainLess5Pct": 0.08929005249338012,
-            "noChange": 0.90757932867188,
-            "loseLess5Pct": 0.0,
+            "gainMore5Pct": 0.00012051059528858203,
+            "gainLess5Pct": 0.05101477918738029,
+            "noChange": 0.9488637004360473,
+            "loseLess5Pct": 1.0097812838801738e-06,
             "loseMore5Pct": 0.0
           },
           "5": {
-            "gainMore5Pct": 0.0047116840344273376,
-            "gainLess5Pct": 0.14648434657916484,
-            "noChange": 0.8488039693864078,
-            "loseLess5Pct": 0.0,
+            "gainMore5Pct": 0.01508409050078559,
+            "gainLess5Pct": 0.08491995599020985,
+            "noChange": 0.899989972305804,
+            "loseLess5Pct": 5.981203200577815e-06,
             "loseMore5Pct": 0.0
           },
           "6": {
-            "gainMore5Pct": 0.02443125535432875,
-            "gainLess5Pct": 0.13774572887235942,
-            "noChange": 0.8377703083289334,
-            "loseLess5Pct": 5.27074443784081e-05,
+            "gainMore5Pct": 0.01204918948130333,
+            "gainLess5Pct": 0.08629746947506002,
+            "noChange": 0.9016532327148542,
+            "loseLess5Pct": 1.0832878247074643e-07,
             "loseMore5Pct": 0.0
           },
           "7": {
-            "gainMore5Pct": 0.027416835275548158,
-            "gainLess5Pct": 0.13898112884908995,
-            "noChange": 0.8336020358753619,
+            "gainMore5Pct": 0.025007704920467735,
+            "gainLess5Pct": 0.16329420292058577,
+            "noChange": 0.8116980921589465,
             "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "8": {
-            "gainMore5Pct": 0.021835682093317446,
-            "gainLess5Pct": 0.08993231065828049,
-            "noChange": 0.8881758211623406,
-            "loseLess5Pct": 5.618608606140641e-05,
+            "gainMore5Pct": 0.020585333843144343,
+            "gainLess5Pct": 0.11544981673432639,
+            "noChange": 0.8639642938418081,
+            "loseLess5Pct": 5.555807212221912e-07,
             "loseMore5Pct": 0.0
           },
           "9": {
-            "gainMore5Pct": 0.051483576037722904,
-            "gainLess5Pct": 0.09199504371049821,
-            "noChange": 0.8564842156381576,
-            "loseLess5Pct": 3.716461362127675e-05,
+            "gainMore5Pct": 0.0533605591730688,
+            "gainLess5Pct": 0.13198358261010146,
+            "noChange": 0.8146558582168297,
+            "loseLess5Pct": 0.0,
             "loseMore5Pct": 0.0
           },
           "10": {
-            "gainMore5Pct": 0.03051785540703619,
-            "gainLess5Pct": 0.1285386808871982,
-            "noChange": 0.8409434637057657,
-            "loseLess5Pct": 0.0,
+            "gainMore5Pct": 0.04203586187455533,
+            "gainLess5Pct": 0.1729737958318899,
+            "noChange": 0.7849861275747149,
+            "loseLess5Pct": 4.21471883986619e-06,
             "loseMore5Pct": 0.0
           }
         }
@@ -133,28 +132,28 @@
     },
     "decile_impact": {
       "relative": {
-        "1": 2.2301492729805984e-05,
-        "2": 2.9324178654485017e-05,
-        "3": 0.002301449776892551,
-        "4": 0.004105008552680521,
-        "5": 0.004078699942135024,
-        "6": 0.007730740535994386,
-        "7": 0.006243146698179237,
-        "8": 0.004907067054593873,
-        "9": 0.008946807010484129,
-        "10": 0.0025061007502895677
+        "1": 0.0003438584151634616,
+        "2": 0.00011390963482187846,
+        "3": 0.0008285299814906455,
+        "4": 0.002259230136275465,
+        "5": 0.004728937944692626,
+        "6": 0.004756668837228493,
+        "7": 0.007977668668425962,
+        "8": 0.008099934054310025,
+        "9": 0.009373108007946612,
+        "10": 0.006538891984988459
       },
       "average": {
-        "1": 0.3475448391437591,
-        "2": 0.9722643899541359,
-        "3": 104.07152721689624,
-        "4": 243.05466026601061,
-        "5": 303.05200107467743,
-        "6": 737.0774991013585,
-        "7": 773.0594863856924,
-        "8": 739.4789845479003,
-        "9": 1824.8816637803718,
-        "10": 2816.978876137759
+        "1": 6.303747775143792,
+        "2": 3.7716613530542418,
+        "3": 36.995443045177105,
+        "4": 128.81576103564154,
+        "5": 329.385465164547,
+        "6": 398.04914891593796,
+        "7": 810.3452222292246,
+        "8": 1035.2973053681249,
+        "9": 1654.6450584054448,
+        "10": 3281.1291344196857
       }
     },
     "district_impacts": null,
@@ -179,7 +178,7 @@
       "analysis_year": 2026,
       "external_comparison": {
         "verdict": "corroborated",
-        "pe_single_year_2026": -94500000000.0,
+        "pe_single_year_2026": -97800000000.0,
         "anchors": [
           {
             "source": "PolicyEngine (prior published, 2024)",
@@ -205,7 +204,7 @@
       }
     },
     "policyengine_us_version": "1.729.3",
-    "dataset_name": "policyengine-us-data",
+    "dataset_name": "populace-us",
     "dataset_version": "1.17.0"
   }
 }


### PR DESCRIPTION
Updated the two published federal analyses with populace numbers. Both still corroborated; HR 1425 child poverty -40% now central vs external anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>