### PR TITLE
Point canonical URLs and base path at /us/bill-tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tracks state and federal tax and transfer legislation relevant to [PolicyEngine](https://policyengine.org), while keeping a state-first browsing experience for state bills. The pipeline scores bills for modelability and computes fiscal impacts using microsimulation.
 
-**Live app:** [state-legislative-tracker.modal.run](https://policengine--state-legislative-tracker.modal.run)
+**Live app:** [policyengine.org/us/bill-tracker](https://www.policyengine.org/us/bill-tracker) (served from [policyengine--state-legislative-tracker.modal.run](https://policyengine--state-legislative-tracker.modal.run))
 
 ## Architecture
 

--- a/modal_app.py
+++ b/modal_app.py
@@ -15,7 +15,7 @@ REPO_URL = "https://github.com/PolicyEngine/state-legislative-tracker.git"
 BRANCH = "main"
 
 # Bump this when source code changes to rebuild the app layer
-APP_VERSION = "v38"
+APP_VERSION = "v39"
 
 # Evaluated at deploy time — unique command string busts Modal's layer cache
 _now = datetime.datetime.utcnow().isoformat()

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.policyengine.org/us/state-legislative-tracker/sitemap.xml
+Sitemap: https://www.policyengine.org/us/bill-tracker/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,262 +1,262 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker</loc>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/AL</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/AL</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/AK</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/AK</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/AZ</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/AZ</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/AR</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/AR</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/CA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/CA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/CO</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/CO</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/CT</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/CT</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/DE</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/DE</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/FL</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/FL</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/GA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/GA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/HI</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/HI</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/ID</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/ID</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/IL</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/IL</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/IN</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/IN</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/IA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/IA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/KS</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/KS</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/KY</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/KY</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/LA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/LA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/ME</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/ME</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MD</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MD</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MI</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MI</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MN</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MN</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MS</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MS</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MO</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MO</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/MT</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/MT</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NE</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NE</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NV</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NV</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NH</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NH</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NJ</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NJ</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NM</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NM</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NY</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NY</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/NC</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/NC</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/ND</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/ND</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/OH</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/OH</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/OK</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/OK</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/OR</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/OR</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/PA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/PA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/RI</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/RI</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/SC</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/SC</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/SD</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/SD</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/TN</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/TN</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/TX</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/TX</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/UT</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/UT</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/VT</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/VT</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/VA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/VA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/WA</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/WA</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/WV</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/WV</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/WI</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/WI</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/WY</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/WY</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.policyengine.org/us/state-legislative-tracker/DC</loc>
+    <loc>https://www.policyengine.org/us/bill-tracker/DC</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -24,7 +24,7 @@ if (!SUPABASE_ANON_KEY) {
   process.exit(1);
 }
 
-const BASE_URL = "https://www.policyengine.org/us/state-legislative-tracker";
+const BASE_URL = "https://www.policyengine.org/us/bill-tracker";
 const DIST = join(dirname(new URL(import.meta.url).pathname), "..", "dist");
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,7 +1,7 @@
 import Script from 'next/script';
 import './globals.css';
 
-const SITE_URL = 'https://www.policyengine.org/us/state-legislative-tracker';
+const SITE_URL = 'https://www.policyengine.org/us/bill-tracker';
 const TITLE = '2026 State Legislative Tracker | PolicyEngine US';
 const DESCRIPTION =
   'Track state-level tax and benefit legislation across all 50 states. See fiscal impacts, winners and losers, and district-level analysis powered by PolicyEngine microsimulation.';

--- a/src/lib/basePath.js
+++ b/src/lib/basePath.js
@@ -1,7 +1,13 @@
 // Resolved at runtime in the browser. Returns '' during SSR/build so the
 // import does not throw on `window` access.
+// Canonical mount is /us/bill-tracker; the old /us/state-legislative-tracker
+// path 308-redirects there on policyengine.org but is kept here so any
+// cached or in-flight page under the old prefix still routes correctly.
+const MOUNT_PREFIXES = ['/us/bill-tracker', '/us/state-legislative-tracker'];
+
 export const BASE_PATH =
-  typeof window !== 'undefined' &&
-  window.location.pathname.startsWith('/us/state-legislative-tracker')
-    ? '/us/state-legislative-tracker'
-    : '';
+  (typeof window !== 'undefined' &&
+    MOUNT_PREFIXES.find((prefix) =>
+      window.location.pathname.startsWith(prefix),
+    )) ||
+  '';


### PR DESCRIPTION
## Summary

policyengine.org is moving the tracker's public URL from `/us/state-legislative-tracker` to `/us/bill-tracker` (the tracker covers federal bills now, and the app already brands itself "Bill Tracker"). This PR points everything the tracker itself emits at the new canonical URL:

- `src/app/layout.jsx` — `SITE_URL` (canonical link, `og:url`, JSON-LD `url`) → `https://www.policyengine.org/us/bill-tracker`
- `scripts/prerender.mjs` — `BASE_URL` for per-bill/state canonical URLs, noscript nav links, and the generated sitemap
- `public/sitemap.xml` / `public/robots.txt` — checked-in fallbacks updated (52 URLs)
- `src/lib/basePath.js` — runtime `BASE_PATH` resolves `/us/bill-tracker` first, keeping `/us/state-legislative-tracker` as a fallback for cached pages during the transition
- `modal_app.py` — `APP_VERSION` v38 → v39 so the cached Modal app layer rebuilds with this code (the Modal app label and URL are unchanged)
- `README.md` — live-app link points at the canonical policyengine.org URL

Kept as-is: the Modal app label (`state-legislative-tracker`) and modal.run URL, the repo name, the GA `tool_name` (analytics continuity), and the `state-legislative-tracker.png` OG image filename.

## Deploy order

Depends on PolicyEngine/policyengine-app-v2#1111 (mounts the `/us/bill-tracker` zone and 308-redirects the old path). **Merge that first** — merging this PR auto-deploys to Modal, and its pages will emit `/us/bill-tracker` URLs.

## Verification

- `next build` (production static export) succeeds; `out/index.html` emits `<link rel="canonical" href="https://www.policyengine.org/us/bill-tracker"/>`, matching `og:url`, and JSON-LD `url`
- 31 vitest tests pass; eslint 0 errors (10 pre-existing warnings in untouched files)
- End-to-end against the app-v2 branch's dev server: `/us/bill-tracker` serves the tracker; old bare/deep paths 308-redirect with paths preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
