### PR TITLE
Emit exactly one canonical per prerendered page

### DIFF
--- a/modal_app.py
+++ b/modal_app.py
@@ -15,7 +15,7 @@ REPO_URL = "https://github.com/PolicyEngine/state-legislative-tracker.git"
 BRANCH = "main"
 
 # Bump this when source code changes to rebuild the app layer
-APP_VERSION = "v39"
+APP_VERSION = "v40"
 
 # Evaluated at deploy time — unique command string busts Modal's layer cache
 _now = datetime.datetime.utcnow().isoformat()

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -107,7 +107,10 @@ function setDescription(html, desc) {
 }
 
 function addCanonical(html, url) {
-  return html.replace("</head>", `    <link rel="canonical" href="${url}" />\n  </head>`);
+  // The Next.js layout bakes a site-level canonical into every exported
+  // page; strip it so each page carries exactly one canonical URL.
+  const stripped = html.replace(/<link rel="canonical"[^>]*\/?>/gi, "");
+  return stripped.replace("</head>", `    <link rel="canonical" href="${url}" />\n  </head>`);
 }
 
 function addNoscript(html, content) {


### PR DESCRIPTION
## Summary

Follow-up to #208. Every statically exported page inherits the Next.js layout's site-level canonical, and `scripts/prerender.mjs` then appended a second per-page one — so live bill and state pages carried two conflicting canonical tags, e.g. on `/us/bill-tracker/WV/wv-sb392`:

```html
<link rel="canonical" href="https://www.policyengine.org/us/bill-tracker"/>          <!-- layout -->
<link rel="canonical" href="https://www.policyengine.org/us/bill-tracker/WV/wv-sb392" />  <!-- prerender -->
```

A homepage canonical on every bill page invites search engines to consolidate bill pages into the homepage. `addCanonical` now strips the baked-in tag before inserting the per-page one. `APP_VERSION` bumped (v39 → v40) so Modal rebuilds the cached app layer.

## Verification

Ran the exact Modal pipeline locally (`next build` → `mv out dist` reshaping → `node scripts/prerender.mjs`, 44 bill pages / 23 states):

- `dist/index.html` — exactly 1 canonical: `/us/bill-tracker`
- `dist/WV/index.html` — exactly 1: `/us/bill-tracker/WV`
- `dist/WV/wv-sb392/index.html` — exactly 1: `/us/bill-tracker/WV/wv-sb392`
- 31 vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
