### PR TITLE
Bump APP_VERSION to v41 to rebuild past a clone race

### DIFF
--- a/modal_app.py
+++ b/modal_app.py
@@ -14,8 +14,12 @@ RUNTIME_SECRET_NAME = "state-research-tracker-runtime"
 REPO_URL = "https://github.com/PolicyEngine/state-legislative-tracker.git"
 BRANCH = "main"
 
-# Bump this when source code changes to rebuild the app layer
-APP_VERSION = "v40"
+# Bump this when source code changes to rebuild the app layer.
+# Caveat: the deploy workflow runs on the same push that bumps this, and the
+# builder clones main independently — if the clone races the push, the bumped
+# cache key can capture the pre-push code (happened at v40). If deployed
+# content looks stale, bump again on a fresh commit.
+APP_VERSION = "v41"
 
 # Evaluated at deploy time — unique command string busts Modal's layer cache
 _now = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
The v40 image (#209's deploy) cloned `main` before the merge push replicated, so its cached app layer has pre-fix code — live bill pages still carry two canonical tags even though the deploy succeeded. Verified the prerender strip regex works against the live production HTML (2 → 0 matches), so the code is right and only the image is stale. Bumping to v41 on a fresh commit forces a clean clone; also documents the race next to `APP_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)