### PR TITLE
Add publish-reform workflow for CRM-dispatched scored reforms

### DIFF
--- a/.github/workflows/publish-reform.yml
+++ b/.github/workflows/publish-reform.yml
@@ -1,0 +1,187 @@
+name: Publish Reform
+
+# Triggered by the CRM publication router (workflow_dispatch) once a human
+# approves adding a scored reform to the bill tracker. Computes impacts from
+# the validated reform_dict, upserts research + reform_impacts to Supabase as
+# in_review (hidden on the site), and opens a bill-review PR — merging that PR
+# fires publish-bill.yml, which flips the entry to published and redeploys.
+on:
+  workflow_dispatch:
+    inputs:
+      id:
+        description: 'Reform slug, e.g. "us-ctc-restoration-2026" (lowercase, [a-z0-9-])'
+        required: true
+        type: string
+      state:
+        description: '"us" for federal, or a 2-letter state code (e.g. "ut")'
+        required: true
+        default: 'us'
+        type: string
+      label:
+        description: 'Short display label (≤60 chars)'
+        required: true
+        type: string
+      reform_json:
+        description: 'Validated reform_dict JSON (param path → {date_range: value}), from /analyze-policy'
+        required: true
+        type: string
+      title:
+        description: 'Research entry title'
+        required: true
+        type: string
+      description:
+        description: 'One-paragraph neutral provisions summary'
+        required: false
+        default: ''
+        type: string
+      tags:
+        description: 'Comma-separated lowercase tags, e.g. "federal,child-tax-credit"'
+        required: false
+        default: ''
+        type: string
+      source_url:
+        description: 'Primary source URL (bill page, news article)'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Compute + validate only: no Supabase write, no PR'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish-reform:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60  # microsim + dataset download dominate
+    permissions:
+      contents: write        # push the bill/{id} branch
+      pull-requests: write   # open the bill-review PR
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install policyengine-us policyengine-us-data supabase numpy pyyaml python-dotenv huggingface_hub
+
+      - name: Build reform config
+        # Inputs come in via env (never inline ${{ }} into shell/python) and are
+        # validated here: id must be a safe slug (it becomes a file path and a
+        # branch name), reform_json must parse as a JSON object.
+        env:
+          REFORM_ID: ${{ inputs.id }}
+          REFORM_STATE: ${{ inputs.state }}
+          REFORM_LABEL: ${{ inputs.label }}
+          REFORM_JSON: ${{ inputs.reform_json }}
+        run: |
+          python3 - << 'EOF'
+          import json, os, re, sys
+          reform_id = os.environ["REFORM_ID"]
+          state = os.environ["REFORM_STATE"].strip().lower()
+          if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", reform_id):
+              sys.exit(f"id {reform_id!r} must match ^[a-z0-9][a-z0-9-]*$")
+          if not re.fullmatch(r"[a-z]{2}", state):
+              sys.exit(f"state {state!r} must be 'us' or a 2-letter state code")
+          reform = json.loads(os.environ["REFORM_JSON"])
+          if not isinstance(reform, dict) or not reform:
+              sys.exit("reform_json must be a non-empty JSON object")
+          config = {
+              "id": reform_id,
+              "state": state,
+              "label": os.environ["REFORM_LABEL"],
+              "reform": reform,
+          }
+          with open("/tmp/reform-config.json", "w") as f:
+              json.dump(config, f, indent=2)
+          print(json.dumps(config, indent=2))
+          EOF
+
+      - name: Compute impacts
+        env:
+          # State datasets (states/XX.h5) and populace-us come from the
+          # policyengine/policyengine-us-data HF repo; token needed if gated.
+          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+          REFORM_ID: ${{ inputs.id }}
+        run: |
+          python scripts/compute_impacts.py \
+            --reform-json /tmp/reform-config.json \
+            --output "analyses/${REFORM_ID}.json"
+
+      - name: Merge research metadata
+        env:
+          REFORM_ID: ${{ inputs.id }}
+          REFORM_STATE: ${{ inputs.state }}
+          REFORM_TITLE: ${{ inputs.title }}
+          REFORM_DESCRIPTION: ${{ inputs.description }}
+          REFORM_TAGS: ${{ inputs.tags }}
+          REFORM_SOURCE_URL: ${{ inputs.source_url }}
+        run: python scripts/merge_research_metadata.py "analyses/${REFORM_ID}.json"
+
+      - name: Upload analysis to Supabase (in_review)
+        if: inputs.dry_run == false
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          REFORM_ID: ${{ inputs.id }}
+        run: python scripts/publish_analysis.py "analyses/${REFORM_ID}.json"
+
+      - name: Validate artifact (dry run)
+        if: inputs.dry_run == true
+        env:
+          REFORM_ID: ${{ inputs.id }}
+        run: python scripts/publish_analysis.py "analyses/${REFORM_ID}.json" --dry-run
+
+      - name: Open bill-review PR
+        if: inputs.dry_run == false
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REFORM_ID: ${{ inputs.id }}
+          REFORM_TITLE: ${{ inputs.title }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="bill/${REFORM_ID}"
+          git checkout -b "$BRANCH"
+          git add "analyses/${REFORM_ID}.json"
+          git commit -m "Add scored reform: ${REFORM_ID}"
+          git push -u origin "$BRANCH" --force
+          PR_URL=$(gh pr create \
+            --title "Publish reform: ${REFORM_TITLE}" \
+            --label bill-review \
+            --body "Automated publication from the CRM research pipeline.
+
+          The reform's impacts were computed by this workflow run and upserted to Supabase as \`in_review\` (hidden on the site). **Merging this PR publishes the entry** on the bill tracker (publish-bill.yml flips status to published and redeploys Modal).
+
+          Artifact: \`analyses/${REFORM_ID}.json\`
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+            --head "$BRANCH" --base main)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Opened $PR_URL"
+
+      - name: Write publication result
+        # Normalized cross-repo contract consumed by the CRM publication
+        # tracker: publication-result artifact containing result.json.
+        if: always()
+        env:
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          python3 -c "import json, os; json.dump({'pr_url': os.environ.get('PR_URL') or None}, open('/tmp/result.json', 'w'))"
+          cat /tmp/result.json
+
+      - name: Upload publication result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publication-result
+          path: |
+            /tmp/result.json
+            analyses/*.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/merge_research_metadata.py
+++ b/scripts/merge_research_metadata.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Merge a research-table row into a computed analysis artifact.
+
+compute_impacts.py --output writes {"reform_impacts": {...}} only; the
+publish-reform workflow (dispatched by the CRM publication router) uses this
+script to add the "research" block that publish_analysis.py upserts alongside
+the impacts. Status is always in_review — 'published' is reserved for the
+publish-bill workflow on PR merge.
+
+Metadata comes in via environment variables (the workflow maps its
+workflow_dispatch inputs onto them):
+
+    REFORM_ID           required, ^[a-z0-9][a-z0-9-]*$
+    REFORM_STATE        required, "us" or a 2-letter state code
+    REFORM_TITLE        required
+    REFORM_DESCRIPTION  optional
+    REFORM_TAGS         optional, comma-separated
+    REFORM_SOURCE_URL   optional
+
+Usage:
+    python scripts/merge_research_metadata.py analyses/us-ctc-restoration.json
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import date
+
+
+def build_key_findings(impacts: dict) -> list[str]:
+    """Derive headline key_findings from the computed impacts record."""
+    findings = []
+
+    budget = impacts.get("budgetary_impact") or {}
+    net_cost = budget.get("netCost")
+    year = (impacts.get("model_notes") or {}).get("analysis_year")
+    version = impacts.get("policyengine_us_version")
+    dataset = impacts.get("dataset_name")
+    if isinstance(net_cost, (int, float)) and net_cost != 0:
+        direction = "Reduces" if net_cost < 0 else "Raises"
+        provenance = ", ".join(
+            p for p in (f"PolicyEngine {dataset or ''}".strip(), f"policyengine-us {version}" if version else "")
+            if p
+        )
+        findings.append(
+            f"{direction} government revenue by ${abs(net_cost) / 1e9:.1f} billion"
+            + (f" in {year}" if year else "")
+            + (f" ({provenance})" if provenance else "")
+        )
+
+    wl = impacts.get("winners_losers") or {}
+    gain = (wl.get("gainMore5Pct") or 0) + (wl.get("gainLess5Pct") or 0)
+    lose = (wl.get("loseMore5Pct") or 0) + (wl.get("loseLess5Pct") or 0)
+    if gain or lose:
+        findings.append(
+            f"{gain * 100:.1f}% of households gain; {lose * 100:.1f}% lose"
+        )
+
+    poverty = impacts.get("poverty_impact") or {}
+    pct = poverty.get("percentChange")
+    if isinstance(pct, (int, float)):
+        if abs(pct) < 0.5:
+            findings.append("No measurable change in overall poverty (SPM)")
+        else:
+            direction = "Reduces" if pct < 0 else "Increases"
+            findings.append(f"{direction} overall poverty by {abs(pct):.1f}% (SPM)")
+
+    return findings
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 1
+    artifact_path = sys.argv[1]
+
+    reform_id = os.environ.get("REFORM_ID", "")
+    state = os.environ.get("REFORM_STATE", "").strip().upper()
+    title = os.environ.get("REFORM_TITLE", "").strip()
+    description = os.environ.get("REFORM_DESCRIPTION", "").strip()
+    tags_raw = os.environ.get("REFORM_TAGS", "")
+    source_url = os.environ.get("REFORM_SOURCE_URL", "").strip()
+
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", reform_id):
+        print(f"Error: REFORM_ID {reform_id!r} must match ^[a-z0-9][a-z0-9-]*$")
+        return 1
+    if not re.fullmatch(r"[A-Z]{2}", state):
+        print(f"Error: REFORM_STATE {state!r} must be 'us' or a 2-letter state code")
+        return 1
+    if not title:
+        print("Error: REFORM_TITLE is required")
+        return 1
+
+    with open(artifact_path) as f:
+        artifact = json.load(f)
+
+    impacts = artifact.get("reform_impacts")
+    if not impacts or impacts.get("id") != reform_id:
+        print(
+            f"Error: artifact reform_impacts.id {impacts.get('id') if impacts else None!r}"
+            f" does not match REFORM_ID {reform_id!r}"
+        )
+        return 1
+
+    tags = [t.strip().lower() for t in tags_raw.split(",") if t.strip()]
+
+    artifact["research"] = {
+        "id": reform_id,
+        "state": state,
+        "type": "bill",
+        "status": "in_review",  # publish-bill.yml flips to published on PR merge
+        "title": title,
+        "url": source_url or None,
+        "date": date.today().isoformat(),
+        "author": "PolicyEngine",
+        "description": description or None,
+        "key_findings": build_key_findings(impacts),
+        "tags": tags,
+    }
+
+    with open(artifact_path, "w") as f:
+        json.dump(artifact, f, indent=2)
+    print(f"Merged research row into {artifact_path} (status=in_review)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part 2 of the CRM reform-publication chain. workflow_dispatch entry point fired by the CRM publication router when a human approves adding a scored reform to the tracker.

## Flow
1. Validates inputs (`id` slug, `state`, `reform_json` must be a JSON object) and writes the `{id, state, label, reform}` config.
2. `compute_impacts.py --reform-json ... --output analyses/<id>.json` (existing offline mode — no DB creds needed for compute).
3. New `scripts/merge_research_metadata.py` adds the `research` row (title/description/tags/url from inputs, `status: in_review`, key_findings derived from the computed impacts — matches the hand-written us-hr904 findings).
4. `publish_analysis.py` upserts both rows to Supabase (existing `SUPABASE_KEY` CI secret) — entry stays hidden as `in_review`.
5. Opens a PR on `bill/<id>` labeled `bill-review` — **merging it publishes** via the existing publish-bill.yml gate (status → published + Modal redeploy).
6. Uploads a `publication-result` artifact (`result.json` with `pr_url`) consumed by the CRM publication tracker.

`dry_run: true` computes + validates without Supabase writes or a PR.

## Notes
- May need a `HUGGING_FACE_TOKEN` secret if the policyengine-us-data HF datasets are gated (the workflow passes it through if present).
- Tested `merge_research_metadata.py` locally against the us-hr904 artifact: research row + key findings reproduce the hand-written entry.

Companion PRs: CRM (publication router) and policyengine-skills (frontmatter + headless create-dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)