### PR TITLE
publish-reform: optional baseline_json for enacted bills

### DIFF
--- a/.github/workflows/publish-reform.yml
+++ b/.github/workflows/publish-reform.yml
@@ -31,6 +31,11 @@ on:
         description: 'Validated reform_dict JSON (param path → {date_range: value}), from /analyze-policy'
         required: true
         type: string
+      baseline_json:
+        description: 'Optional baseline override (same JSON shape). For ENACTED bills already in the policyengine-us baseline: set this to the prior-law counterfactual and reform_json to the bill, so impacts carry the bill''s true effect and signs.'
+        required: false
+        default: ''
+        type: string
       title:
         description: 'Research entry title'
         required: true
@@ -94,6 +99,7 @@ jobs:
           REFORM_STATE: ${{ inputs.state }}
           REFORM_LABEL: ${{ inputs.label }}
           REFORM_JSON: ${{ inputs.reform_json }}
+          BASELINE_JSON: ${{ inputs.baseline_json }}
         run: |
           python3 - << 'EOF'
           import json, os, re, sys
@@ -106,11 +112,18 @@ jobs:
           reform = json.loads(os.environ["REFORM_JSON"])
           if not isinstance(reform, dict) or not reform:
               sys.exit("reform_json must be a non-empty JSON object")
+          baseline_raw = os.environ.get("BASELINE_JSON", "").strip()
+          baseline = None
+          if baseline_raw:
+              baseline = json.loads(baseline_raw)
+              if not isinstance(baseline, dict) or not baseline:
+                  sys.exit("baseline_json, when set, must be a non-empty JSON object")
           config = {
               "id": reform_id,
               "state": state,
               "label": os.environ["REFORM_LABEL"],
               "reform": reform,
+              "baseline": baseline,
           }
           with open("/tmp/reform-config.json", "w") as f:
               json.dump(config, f, indent=2)

--- a/scripts/compute_impacts.py
+++ b/scripts/compute_impacts.py
@@ -290,9 +290,15 @@ def create_reform_class(reform_params: dict):
     return DynamicReform
 
 
-def run_simulations(state: str, reform_params: dict, year: int = 2026):
+def run_simulations(state: str, reform_params: dict, year: int = 2026, baseline_params: dict | None = None):
     """
     Run baseline and reform microsimulations.
+
+    ``baseline_params`` overrides the baseline with a custom parameter set —
+    needed when scoring an ENACTED bill that is already current law in the
+    installed policyengine-us release. There the counterfactual (prior law)
+    is the baseline and the bill's parameters are the reform, so impacts come
+    out with the bill's true effect and correct signs.
 
     Returns tuple of (baseline, reformed) Microsimulation objects.
     """
@@ -306,7 +312,15 @@ def run_simulations(state: str, reform_params: dict, year: int = 2026):
     ReformClass = create_reform_class(reform_params)
 
     print("    Running baseline simulation...")
-    baseline = Microsimulation(dataset=dataset) if dataset else Microsimulation()
+    if baseline_params:
+        BaselineClass = create_reform_class(baseline_params)
+        baseline = (
+            Microsimulation(reform=BaselineClass, dataset=dataset)
+            if dataset
+            else Microsimulation(reform=BaselineClass)
+        )
+    else:
+        baseline = Microsimulation(dataset=dataset) if dataset else Microsimulation()
 
     print("    Running reform simulation...")
     reformed = (
@@ -888,6 +902,7 @@ Examples:
             "state": config["state"].lower(),
             "label": config.get("label", config["id"]),
             "reform": config["reform"],
+            "baseline": config.get("baseline"),
             "computed": False,
         }]
     else:
@@ -937,7 +952,9 @@ Examples:
 
             # Run simulations
             print("  [1/6] Running microsimulations...")
-            baseline, reformed = run_simulations(state, reform["reform"], sim_year)
+            baseline, reformed = run_simulations(
+                state, reform["reform"], sim_year, baseline_params=reform.get("baseline")
+            )
 
             # Compute all impacts
             print("  [2/6] Computing budgetary impact...")


### PR DESCRIPTION
Scoring GA HB 463 exposed a gap: the bill is already current law in the installed policyengine-us release, so `compute_impacts.py`'s reform-vs-current-law framing either produces a no-op (forward dict) or sign-flipped impacts (counterfactual dict). This will recur for every enacted bill — the model bakes in enacted law quickly.

- `publish-reform.yml`: new optional `baseline_json` input (same shape as `reform_json`), validated like the reform dict
- `compute_impacts.py`: `run_simulations()` accepts `baseline_params` — when set, the baseline sim applies that parameter set (the prior-law counterfactual), so reform-vs-baseline is the bill's true effect

Usage for enacted bills: `baseline_json` = prior-law parameters, `reform_json` = the bill's parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)