### PR TITLE
publish-reform: upgrade policyengine-us past the data package's pin

### DIFF
--- a/.github/workflows/publish-reform.yml
+++ b/.github/workflows/publish-reform.yml
@@ -78,7 +78,14 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install policyengine-us policyengine-us-data supabase numpy pyyaml python-dotenv huggingface_hub
+        # policyengine-us-data pins an old policyengine-us (currently ==1.693.5),
+        # which predates recently-added state parameters (e.g. GA HB463's
+        # flat_rate). Install data first, then upgrade the model — the same
+        # current-model pairing the hosted API scores against.
+        run: |
+          pip install policyengine-us-data supabase numpy pyyaml python-dotenv huggingface_hub
+          pip install --upgrade policyengine-us
+          python -c 'import policyengine_us, policyengine_us_data; print("model", policyengine_us.__version__, "/ data", policyengine_us_data.__version__)'
 
       - name: Add swap
         # The national (populace-us) microsim peaks above the 16GB hosted-runner


### PR DESCRIPTION
The GA HB 463 dry run failed with `'ParameterNode' object has no attribute 'flat_rate'`: `policyengine-us-data 1.115.4` pins `policyengine-us==1.693.5`, so pip backtracked to a model predating the GA flat-tax parameters (~1.764). Install the data package first, then `pip install --upgrade policyengine-us`, and print both versions in the log. This matches the pairing the hosted API scores against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)