### PR TITLE
publish-reform: version print via importlib.metadata

### DIFF
--- a/.github/workflows/publish-reform.yml
+++ b/.github/workflows/publish-reform.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           pip install policyengine-us-data supabase numpy pyyaml python-dotenv huggingface_hub
           pip install --upgrade policyengine-us
-          python -c 'import policyengine_us, policyengine_us_data; print("model", policyengine_us.__version__, "/ data", policyengine_us_data.__version__)'
+          python -c 'from importlib.metadata import version; print("model", version("policyengine-us"), "/ data", version("policyengine-us-data"))'
 
       - name: Add swap
         # The national (populace-us) microsim peaks above the 16GB hosted-runner


### PR DESCRIPTION
The verify line added in #213 used `policyengine_us.__version__`, which the package doesn't expose — the install step exited 1 after a successful upgrade. Use `importlib.metadata.version()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)